### PR TITLE
Upgrade js-yaml to fix security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4026,9 +4026,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
upgrade js-yaml from `3.13.0` to `3.13.1`.
`tar` package also has security vulnerability, but the latest version of `node-gyp` package(requires `tar` package) still uses a version of `tar` includes security vulnerability.

```
$ npm audit

                       === npm audit security report ===

# Run  npm update js-yaml --depth 6  to resolve 3 vulnerabilities

  High            Code Injection

  Package         js-yaml

  Dependency of   eslint [dev]

  Path            eslint > js-yaml

  More info       https://nodesecurity.io/advisories/813




  High            Code Injection

  Package         js-yaml

  Dependency of   grunt [dev]

  Path            grunt > js-yaml

  More info       https://nodesecurity.io/advisories/813




  High            Code Injection

  Package         js-yaml

  Dependency of   jest [dev]

  Path            jest > jest-cli > @jest/core > @jest/reporters >
                  istanbul-api > js-yaml

  More info       https://nodesecurity.io/advisories/813




                                 Manual Review
             Some vulnerabilities require your attention to resolve

          Visit https://go.npm.me/audit-guide for additional guidance


  High            Arbitrary File Overwrite

  Package         tar

  Patched in      >=4.4.2

  Dependency of   node-gyp [dev]

  Path            node-gyp > tar

  More info       https://nodesecurity.io/advisories/803
```