### PR TITLE
added serialize/deserialize methods to set custom startMessageId in createReader 

### DIFF
--- a/src/MessageId.h
+++ b/src/MessageId.h
@@ -31,6 +31,8 @@ class MessageId : public Napi::ObjectWrap<MessageId> {
   static Napi::Object NewInstanceFromMessage(const Napi::CallbackInfo &info, pulsar_message_t *cMessage);
   static Napi::Value Earliest(const Napi::CallbackInfo &info);
   static Napi::Value Latest(const Napi::CallbackInfo &info);
+  Napi::Value Serialize(const Napi::CallbackInfo &info);
+  static Napi::Value Deserialize(const Napi::CallbackInfo &info);
   static void Finalize(const Napi::CallbackInfo &info);
   MessageId(const Napi::CallbackInfo &info);
   ~MessageId();


### PR DESCRIPTION
To restore Reader from the custom message needs to provide startMessageId
```js
const msg = await reader.readNext();
const msgId = msg.getMessageId().serialize() // native Buffer
msgId.toString("hex") // returns "085a10002000" as binary string
```
The cursor can be restored from binary string
```js
const msgId = Buffer.from("085a10002000", "hex")
const reader = await client.createReader({
	topic: 'persistent://public/default/my-topic',
	startMessageId: Pulsar.MessageId.deserialize(msgId)
});
```