### PR TITLE
added node-pre-gyp support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "example": "examples"
   },
   "scripts": {
+    "install": "node-pre-gyp install --fallback-to-build",
     "clean": "node-gyp clean",
     "configure": "node-gyp configure",
     "lint": "eslint --ext .js .",
@@ -38,11 +39,17 @@
     "grunt-license-report": "^0.0.8",
     "hdr-histogram-js": "^1.1.4",
     "jest": "^24.7.1",
-    "lodash": "^4.17.11",
-    "node-addon-api": "^1.6.2",
-    "node-gyp": "^3.8.0"
+    "lodash": "^4.17.11"
   },
   "dependencies": {
-    "bindings": "^1.3.1"
+    "bindings": "^1.3.1",
+    "node-addon-api": "^1.6.2",
+    "node-gyp": "^3.8.0",
+    "node-pre-gyp": "^0.12.0"
+  },
+  "binary": {
+    "module_name": "libpulsar",
+    "module_path": "./build/Release",
+    "host": "https://pulsar.apache.org/docs/en/client-libraries-cpp/"
   }
 }


### PR DESCRIPTION
Library ```pulsar-client-cpp``` still needs to be installed in OS manually but it helps to install the package via npm from github/npm registry 
```sh
npm i apache/pulsar-client-node#master #from github
npm i pulsar-client #from npm registry
```
The package is ready to be published to npm registry via command
```sh
npm publish
```