### PR TITLE
[Issue #39]Add skip flag for cMessageId free

### DIFF
--- a/src/MessageId.cc
+++ b/src/MessageId.cc
@@ -70,6 +70,7 @@ Napi::Value MessageId::Earliest(const Napi::CallbackInfo &info) {
   Napi::Object obj = NewInstance(info[0]);
   MessageId *msgId = Unwrap(obj);
   msgId->cMessageId = (pulsar_message_id_t *)pulsar_message_id_earliest();
+  msgId->skipcMessageIdFree = true;
   return obj;
 }
 
@@ -77,6 +78,7 @@ Napi::Value MessageId::Latest(const Napi::CallbackInfo &info) {
   Napi::Object obj = NewInstance(info[0]);
   MessageId *msgId = Unwrap(obj);
   msgId->cMessageId = (pulsar_message_id_t *)pulsar_message_id_latest();
+  msgId->skipcMessageIdFree = true;
   return obj;
 }
 
@@ -113,4 +115,8 @@ Napi::Value MessageId::ToString(const Napi::CallbackInfo &info) {
   return Napi::String::New(info.Env(), pulsar_message_id_str(this->cMessageId));
 }
 
-MessageId::~MessageId() { pulsar_message_id_free(this->cMessageId); }
+MessageId::~MessageId() {
+  if (!this->skipcMessageIdFree) {
+    pulsar_message_id_free(this->cMessageId);
+  }
+}

--- a/src/MessageId.cc
+++ b/src/MessageId.cc
@@ -70,7 +70,7 @@ Napi::Value MessageId::Earliest(const Napi::CallbackInfo &info) {
   Napi::Object obj = NewInstance(info[0]);
   MessageId *msgId = Unwrap(obj);
   msgId->cMessageId = (pulsar_message_id_t *)pulsar_message_id_earliest();
-  msgId->skipcMessageIdFree = true;
+  msgId->skipCMessageIdFree = true;
   return obj;
 }
 
@@ -78,7 +78,7 @@ Napi::Value MessageId::Latest(const Napi::CallbackInfo &info) {
   Napi::Object obj = NewInstance(info[0]);
   MessageId *msgId = Unwrap(obj);
   msgId->cMessageId = (pulsar_message_id_t *)pulsar_message_id_latest();
-  msgId->skipcMessageIdFree = true;
+  msgId->skipCMessageIdFree = true;
   return obj;
 }
 
@@ -116,7 +116,7 @@ Napi::Value MessageId::ToString(const Napi::CallbackInfo &info) {
 }
 
 MessageId::~MessageId() {
-  if (!this->skipcMessageIdFree) {
+  if (!this->skipCMessageIdFree) {
     pulsar_message_id_free(this->cMessageId);
   }
 }

--- a/src/MessageId.h
+++ b/src/MessageId.h
@@ -41,6 +41,7 @@ class MessageId : public Napi::ObjectWrap<MessageId> {
  private:
   static Napi::FunctionReference constructor;
   pulsar_message_id_t *cMessageId;
+  bool skipcMessageIdFree = false;
 
   Napi::Value ToString(const Napi::CallbackInfo &info);
 };

--- a/src/MessageId.h
+++ b/src/MessageId.h
@@ -41,7 +41,7 @@ class MessageId : public Napi::ObjectWrap<MessageId> {
  private:
   static Napi::FunctionReference constructor;
   pulsar_message_id_t *cMessageId;
-  bool skipcMessageIdFree = false;
+  bool skipCMessageIdFree = false;
 
   Napi::Value ToString(const Napi::CallbackInfo &info);
 };


### PR DESCRIPTION
It seems that [the issue](https://github.com/apache/pulsar-client-node/issues/39) occurs when gc releases `earliest(latest) messageId`.
These messageIds shouldn't be released.

In go client library, it doesn't call `pulsar_message_id_free()` if messageid is earliest or latest.
https://github.com/apache/pulsar/blob/d5036eaefcba42e6c9d159ffb14bee597d13380f/pulsar-client-go/pulsar/c_message.go#L198-L206
https://github.com/apache/pulsar/blob/d5036eaefcba42e6c9d159ffb14bee597d13380f/pulsar-client-go/pulsar/c_message.go#L169-L177