### PR TITLE
statsIntervalInSeconds can be 0 to disable log

### DIFF
--- a/src/Client.cc
+++ b/src/Client.cc
@@ -134,9 +134,7 @@ Client::Client(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Client>(info) 
 
   if (clientConfig.Has(CFG_STATS_INTERVAL) && clientConfig.Get(CFG_STATS_INTERVAL).IsNumber()) {
     uint32_t statsIntervalInSeconds = clientConfig.Get(CFG_STATS_INTERVAL).ToNumber().Uint32Value();
-    if (statsIntervalInSeconds > 0) {
-      pulsar_client_configuration_set_stats_interval_in_seconds(cClientConfig, statsIntervalInSeconds);
-    }
+    pulsar_client_configuration_set_stats_interval_in_seconds(cClientConfig, statsIntervalInSeconds);
   }
 
   this->cClient = pulsar_client_create(serviceUrl.Utf8Value().c_str(), cClientConfig);


### PR DESCRIPTION
```pulsar-client-cpp/include/pulsar/ClientConfiguration.h```
```cpp
/*
 * Initialize stats interval in seconds. Stats are printed and reset after every 'statsIntervalInSeconds'.
 * Set to 0 in order to disable stats collection.
 */
ClientConfiguration& setStatsIntervalInSeconds(const unsigned int&);
```
By default it is 10 minutes, to disable stats log needs to be 0