### PR TITLE
Fix compilation warning

### DIFF
--- a/src/MessageId.cc
+++ b/src/MessageId.cc
@@ -27,14 +27,12 @@ Napi::Object MessageId::Init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
 
   Napi::Function func = DefineClass(env, "MessageId",
-                                    {
-                                        StaticMethod("earliest", &MessageId::Earliest, napi_static),
-                                        StaticMethod("latest", &MessageId::Latest, napi_static),
-                                        StaticMethod("finalize", &MessageId::Finalize, napi_static),
-                                        InstanceMethod("serialize", &MessageId::Serialize),
-                                        StaticMethod("deserialize", &MessageId::Deserialize, napi_static),
-                                        InstanceMethod("toString", &MessageId::ToString)
-                                    });
+                                    {StaticMethod("earliest", &MessageId::Earliest, napi_static),
+                                     StaticMethod("latest", &MessageId::Latest, napi_static),
+                                     StaticMethod("finalize", &MessageId::Finalize, napi_static),
+                                     InstanceMethod("serialize", &MessageId::Serialize),
+                                     StaticMethod("deserialize", &MessageId::Deserialize, napi_static),
+                                     InstanceMethod("toString", &MessageId::ToString)});
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();

--- a/src/ReaderConfig.h
+++ b/src/ReaderConfig.h
@@ -34,9 +34,9 @@ class ReaderConfig {
   std::string GetTopic();
 
  private:
-  pulsar_reader_configuration_t *cReaderConfig;
-  pulsar_message_id_t *cStartMessageId;
   std::string topic;
+  pulsar_message_id_t *cStartMessageId;
+  pulsar_reader_configuration_t *cReaderConfig;
 };
 
 #endif


### PR DESCRIPTION
Fixed the following warnings when compiling C++ source.
```
In file included from ../src/ReaderConfig.cc:20:0:
../src/ReaderConfig.h: In constructor 'ReaderConfig::ReaderConfig(const Napi::Object&)':
../src/ReaderConfig.h:39:15: warning: 'ReaderConfig::topic' will be initialized after [-Wreorder]
   std::string topic;
               ^
../src/ReaderConfig.h:38:24: warning:   'pulsar_message_id_t* ReaderConfig::cStartMessageId' [-Wreorder]
   pulsar_message_id_t *cStartMessageId;
                        ^
../src/ReaderConfig.cc:30:1: warning:   when initialized here [-Wreorder]
 ReaderConfig::ReaderConfig(const Napi::Object &readerConfig) : topic(""), cStartMessageId(NULL) {
 ^
  SOLINK_MODULE(target) Release/obj.target/Pulsar.node
  COPY Release/Pulsar.node
make: Leaving directory `/home/massakam/github/pulsar-client-node/build'
```