### PR TITLE
Change initial version to 0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@
 
 The Pulsar Node.js client can be used to create Pulsar producers and consumers in Node.js.
 
-## Compatibility
-
-This Node.js client is developed and tested using Apache Pulsar 2.3.0
-
 ## Requirements
 
 Pulsar Node.js client library is based on the C++ client library. Follow the instructions for
@@ -39,6 +35,16 @@ Pulsar Node.js client library is based on the C++ client library. Follow the ins
 
 Also, this library works only in Node.js 10.x or later because it uses the
 [node-addon-api](https://github.com/nodejs/node-addon-api) module to wrap the C++ library.
+
+## Compatibility
+
+Compatibility between each version of the Node.js client and the C++ client is as follows:
+
+| Node.js client | C++ client     |
+|----------------|----------------|
+| 0.0.1          | 2.3.0 or later |
+
+If an incompatible version of the C++ client is installed, you may fail to build or run this library.
 
 ## How to build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pulsar-client",
-  "version": "2.4.0-SNAPSHOT",
+  "version": "0.0.1-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulsar-client",
-  "version": "2.4.0-SNAPSHOT",
+  "version": "0.0.1-rc.0",
   "description": "Pulsar Node.js client",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Set the first release version of this library to 0.0.1.

I don't think the version of the Node.js client needs to match the C++ client. The current version is 2.4.0-SNAPSHOT, but this library does not support all the features that the C++ client 2.4.0 has.

I think that independent versioning has the advantage that it can determine the release timing flexibly.

cf.
- https://gist.github.com/k2la/6de068df6b55b648fd2a9e995eb62561
- https://github.com/apache/pulsar-client-node/wiki/Release-process