### PR TITLE
Change first release version to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Compatibility between each version of the Node.js client and the C++ client is a
 
 | Node.js client | C++ client     |
 |----------------|----------------|
-| 0.0.1          | 2.3.0 or later |
+| 1.0.0          | 2.3.0 or later |
 
 If an incompatible version of the C++ client is installed, you may fail to build or run this library.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pulsar-client",
-  "version": "0.1.0-rc.0",
+  "version": "1.0.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulsar-client",
-  "version": "0.1.0-rc.0",
+  "version": "1.0.0-rc.0",
   "description": "Pulsar Node.js client",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Initially, I was planning to make the first release version 0.0.1 (https://github.com/apache/pulsar-client-node/pull/48), but there is an opinion that it should be 1.0.0, so I will change the version.