### PR TITLE
Add listener support for consumer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2156,7 +2156,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2571,7 +2572,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2627,6 +2629,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2670,12 +2673,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4688,9 +4693,9 @@
       "dev": true
     },
     "node-addon-api": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
+      "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
     },
     "node-gyp": {
       "version": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "Apache-2.0",
   "gypfile": true,
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=10.16.0"
   },
   "devDependencies": {
     "clang-format": "^1.2.4",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "bindings": "^1.3.1",
-    "node-addon-api": "^1.6.2",
+    "node-addon-api": "^2.0.0",
     "node-gyp": "^3.8.0",
     "node-pre-gyp": "^0.12.0"
   },

--- a/src/Consumer.h
+++ b/src/Consumer.h
@@ -22,6 +22,7 @@
 
 #include <napi.h>
 #include <pulsar/c/client.h>
+#include "ConsumerConfig.h"
 
 class Consumer : public Napi::ObjectWrap<Consumer> {
  public:
@@ -30,10 +31,12 @@ class Consumer : public Napi::ObjectWrap<Consumer> {
   static Napi::FunctionReference constructor;
   Consumer(const Napi::CallbackInfo &info);
   ~Consumer();
-  void SetCConsumer(pulsar_consumer_t *cConsumer);
+  void SetCConsumer(std::shared_ptr<CConsumerWrapper> cConsumer);
+  void SetListenerCallback(ListenerCallback *listener);
 
  private:
-  pulsar_consumer_t *cConsumer;
+  std::shared_ptr<CConsumerWrapper> wrapper;
+  ListenerCallback *listener;
 
   Napi::Value Receive(const Napi::CallbackInfo &info);
   void Acknowledge(const Napi::CallbackInfo &info);

--- a/src/ConsumerConfig.cc
+++ b/src/ConsumerConfig.cc
@@ -18,7 +18,10 @@
  */
 
 #include "ConsumerConfig.h"
+#include "Consumer.h"
+#include "Message.h"
 #include <pulsar/c/consumer_configuration.h>
+#include <pulsar/c/consumer.h>
 #include <map>
 
 static const std::string CFG_TOPIC = "topic";
@@ -30,14 +33,46 @@ static const std::string CFG_RECV_QUEUE = "receiverQueueSize";
 static const std::string CFG_RECV_QUEUE_ACROSS_PARTITIONS = "receiverQueueSizeAcrossPartitions";
 static const std::string CFG_CONSUMER_NAME = "consumerName";
 static const std::string CFG_PROPS = "properties";
+static const std::string CFG_LISTENER = "listener";
 
 static const std::map<std::string, pulsar_consumer_type> SUBSCRIPTION_TYPE = {
     {"Exclusive", pulsar_ConsumerExclusive},
     {"Shared", pulsar_ConsumerShared},
     {"Failover", pulsar_ConsumerFailover}};
 
-ConsumerConfig::ConsumerConfig(const Napi::Object &consumerConfig)
-    : topic(""), subscription(""), ackTimeoutMs(0), nAckRedeliverTimeoutMs(60000) {
+struct MessageListenerProxyData {
+  std::shared_ptr<CConsumerWrapper> consumerWrapper;
+  pulsar_message_t *cMessage;
+
+  MessageListenerProxyData(std::shared_ptr<CConsumerWrapper> consumerWrapper, pulsar_message_t *cMessage)
+      : consumerWrapper(consumerWrapper), cMessage(cMessage) {}
+};
+
+void MessageListenerProxy(Napi::Env env, Napi::Function jsCallback, MessageListenerProxyData *data) {
+  Napi::Object msg = Message::NewInstance({}, data->cMessage);
+  Napi::Object consumerObj = Consumer::constructor.New({});
+  Consumer *consumer = Consumer::Unwrap(consumerObj);
+  consumer->SetCConsumer(std::move(data->consumerWrapper));
+  delete data;
+  jsCallback.Call({msg, consumerObj});
+}
+
+void MessageListener(pulsar_consumer_t *cConsumer, pulsar_message_t *cMessage, void *ctx) {
+  ListenerCallback *listenerCallback = (ListenerCallback *)ctx;
+  if (listenerCallback->callback.Acquire() != napi_ok) {
+    return;
+  };
+  MessageListenerProxyData *dataPtr =
+      new MessageListenerProxyData(listenerCallback->consumerWrapper, cMessage);
+  listenerCallback->callback.BlockingCall(dataPtr, MessageListenerProxy);
+  listenerCallback->callback.Release();
+}
+
+void FinalizeListenerCallback(Napi::Env env, ListenerCallback *cb, void *) { delete cb; }
+
+ConsumerConfig::ConsumerConfig(const Napi::Object &consumerConfig,
+                               std::shared_ptr<CConsumerWrapper> consumerWrapper)
+    : topic(""), subscription(""), ackTimeoutMs(0), nAckRedeliverTimeoutMs(60000), listener(nullptr) {
   this->cConsumerConfig = pulsar_consumer_configuration_create();
 
   if (consumerConfig.Has(CFG_TOPIC) && consumerConfig.Get(CFG_TOPIC).IsString()) {
@@ -68,10 +103,12 @@ ConsumerConfig::ConsumerConfig(const Napi::Object &consumerConfig)
     }
   }
 
-  if (consumerConfig.Has(CFG_NACK_REDELIVER_TIMEOUT) && consumerConfig.Get(CFG_NACK_REDELIVER_TIMEOUT).IsNumber()) {
+  if (consumerConfig.Has(CFG_NACK_REDELIVER_TIMEOUT) &&
+      consumerConfig.Get(CFG_NACK_REDELIVER_TIMEOUT).IsNumber()) {
     this->nAckRedeliverTimeoutMs = consumerConfig.Get(CFG_NACK_REDELIVER_TIMEOUT).ToNumber().Int64Value();
     if (this->nAckRedeliverTimeoutMs >= 0) {
-      pulsar_configure_set_negative_ack_redelivery_delay_ms(this->cConsumerConfig, this->nAckRedeliverTimeoutMs);
+      pulsar_configure_set_negative_ack_redelivery_delay_ms(this->cConsumerConfig,
+                                                            this->nAckRedeliverTimeoutMs);
     }
   }
 
@@ -102,13 +139,43 @@ ConsumerConfig::ConsumerConfig(const Napi::Object &consumerConfig)
       pulsar_consumer_configuration_set_property(this->cConsumerConfig, key.c_str(), value.c_str());
     }
   }
+
+  if (consumerConfig.Has(CFG_LISTENER) && consumerConfig.Get(CFG_LISTENER).IsFunction()) {
+    this->listener = new ListenerCallback();
+    this->listener->consumerWrapper = consumerWrapper;
+    Napi::ThreadSafeFunction callback = Napi::ThreadSafeFunction::New(
+        consumerConfig.Env(), consumerConfig.Get(CFG_LISTENER).As<Napi::Function>(), "Listener Callback", 1,
+        1, (void *)NULL, FinalizeListenerCallback, listener);
+    this->listener->callback = std::move(callback);
+    pulsar_consumer_configuration_set_message_listener(this->cConsumerConfig, &MessageListener,
+                                                       this->listener);
+  }
 }
 
-ConsumerConfig::~ConsumerConfig() { pulsar_consumer_configuration_free(this->cConsumerConfig); }
+ConsumerConfig::~ConsumerConfig() {
+  pulsar_consumer_configuration_free(this->cConsumerConfig);
+  if (this->listener) {
+    this->listener->callback.Release();
+  }
+}
 
 pulsar_consumer_configuration_t *ConsumerConfig::GetCConsumerConfig() { return this->cConsumerConfig; }
 
 std::string ConsumerConfig::GetTopic() { return this->topic; }
 std::string ConsumerConfig::GetSubscription() { return this->subscription; }
+ListenerCallback *ConsumerConfig::GetListenerCallback() {
+  ListenerCallback *cb = this->listener;
+  this->listener = nullptr;
+  return cb;
+}
+
 int64_t ConsumerConfig::GetAckTimeoutMs() { return this->ackTimeoutMs; }
 int64_t ConsumerConfig::GetNAckRedeliverTimeoutMs() { return this->nAckRedeliverTimeoutMs; }
+
+CConsumerWrapper::CConsumerWrapper() : cConsumer(nullptr) {}
+
+CConsumerWrapper::~CConsumerWrapper() {
+  if (this->cConsumer) {
+    pulsar_consumer_free(this->cConsumer);
+  }
+}

--- a/src/ConsumerConfig.h
+++ b/src/ConsumerConfig.h
@@ -25,15 +25,27 @@
 
 #define MIN_ACK_TIMEOUT_MILLIS 10000
 
+struct CConsumerWrapper {
+  pulsar_consumer_t *cConsumer;
+  CConsumerWrapper();
+  ~CConsumerWrapper();
+};
+
+struct ListenerCallback {
+  Napi::ThreadSafeFunction callback;
+  std::shared_ptr<CConsumerWrapper> consumerWrapper;
+};
+
 class ConsumerConfig {
  public:
-  ConsumerConfig(const Napi::Object &consumerConfig);
+  ConsumerConfig(const Napi::Object &consumerConfig, std::shared_ptr<CConsumerWrapper> consumerWrapper);
   ~ConsumerConfig();
   pulsar_consumer_configuration_t *GetCConsumerConfig();
   std::string GetTopic();
   std::string GetSubscription();
   int64_t GetAckTimeoutMs();
   int64_t GetNAckRedeliverTimeoutMs();
+  ListenerCallback *GetListenerCallback();
 
  private:
   pulsar_consumer_configuration_t *cConsumerConfig;
@@ -41,6 +53,7 @@ class ConsumerConfig {
   std::string subscription;
   int64_t ackTimeoutMs;
   int64_t nAckRedeliverTimeoutMs;
+  ListenerCallback *listener;
 };
 
 #endif

--- a/src/MessageId.cc
+++ b/src/MessageId.cc
@@ -29,7 +29,7 @@ Napi::Object MessageId::Init(Napi::Env env, Napi::Object exports) {
   Napi::Function func = DefineClass(env, "MessageId",
                                     {StaticMethod("earliest", &MessageId::Earliest, napi_static),
                                      StaticMethod("latest", &MessageId::Latest, napi_static),
-                                     StaticMethod("finalize", &MessageId::Finalize, napi_static),
+                                     StaticMethod("finalize", &MessageId::Free, napi_static),
                                      InstanceMethod("serialize", &MessageId::Serialize),
                                      StaticMethod("deserialize", &MessageId::Deserialize, napi_static),
                                      InstanceMethod("toString", &MessageId::ToString)});
@@ -58,7 +58,7 @@ Napi::Object MessageId::NewInstance(Napi::Value arg) {
   return obj;
 }
 
-void MessageId::Finalize(const Napi::CallbackInfo &info) {
+void MessageId::Free(const Napi::CallbackInfo &info) {
   Napi::Object obj = info[0].As<Napi::Object>();
   MessageId *msgId = Unwrap(obj);
   pulsar_message_id_free(msgId->cMessageId);

--- a/src/MessageId.h
+++ b/src/MessageId.h
@@ -33,7 +33,7 @@ class MessageId : public Napi::ObjectWrap<MessageId> {
   static Napi::Value Latest(const Napi::CallbackInfo &info);
   Napi::Value Serialize(const Napi::CallbackInfo &info);
   static Napi::Value Deserialize(const Napi::CallbackInfo &info);
-  static void Finalize(const Napi::CallbackInfo &info);
+  static void Free(const Napi::CallbackInfo &info);
   MessageId(const Napi::CallbackInfo &info);
   ~MessageId();
   pulsar_message_id_t *GetCMessageId();


### PR DESCRIPTION
Adds support for a listener function to the Consumer, using the C++ client listener support.

Using `Receive` currently will block a thread from the Node worker poll. If enough consumers are waiting to receive messages from pulsar at the same time, this will completely clog the worker poll.

Since #14, `node-addon-api` has added support for `ThreadSafeFunction`'s, allowing callbacks to be made from native threads. This pull request updates the `node-addon-api` dependency version to use this, but that will increase the minimum supported node version.

This paves the way to use the async functions from the pulsar C++ client properly.