### PR TITLE
Check code format before unit tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,14 @@
     "no-console": "off",
     "no-unused-vars": "warn"
   },
+  "overrides": [
+    {
+      "files": ["tests/*.js"],
+      "rules": {
+        "no-await-in-loop": "off"
+      }
+    }
+  ],
   "globals": {
     "describe": true,
     "test": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,6 +382,54 @@
         "@types/yargs": "^12.0.9"
       }
     },
+    "@seadub/clang-format-lint": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@seadub/clang-format-lint/-/clang-format-lint-0.0.2.tgz",
+      "integrity": "sha512-0P/NUsIpUsP5MJ9WpEmBMlCQY2zFJDVkstrl+jb8EsWNixeshfzQYxlAeabbEbT4Buixuelr/HKLphyZB1rDYA==",
+      "dev": true,
+      "requires": {
+        "commander": "^3.0.2",
+        "glob": "^7.1.4",
+        "p-limit": "^2.2.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        }
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "install": "node-pre-gyp install --fallback-to-build",
     "clean": "node-gyp clean",
     "configure": "node-gyp configure",
-    "lint": "eslint --ext .js .",
-    "format": "clang-format -i --verbose src/* && eslint --fix --ext .js .",
+    "lint": "clang-format-lint src/*.cc src/*.h && eslint --ext .js .",
+    "format": "clang-format-lint --fix src/*.cc src/*.h && eslint --fix --ext .js .",
     "build": "npm run format && node-gyp rebuild",
     "build:debug": "npm run format && node-gyp rebuild --debug",
     "license:report": "mkdir -p report && grunt grunt-license-report",
@@ -30,6 +30,7 @@
     "node": ">=10.16.0"
   },
   "devDependencies": {
+    "@seadub/clang-format-lint": "0.0.2",
     "clang-format": "^1.2.4",
     "commander": "^2.20.0",
     "delay": "^4.3.0",

--- a/run-unit-tests.sh
+++ b/run-unit-tests.sh
@@ -33,7 +33,7 @@ done;
 apt install $PULSAR_PKG_DIR/apache-pulsar-client*.deb
 
 ./pulsar-test-service-start.sh
-npm install && npm run build && npm run test
+npm install && npm run lint && npm run build && npm run test
 RES=$?
 ./pulsar-test-service-stop.sh
 


### PR DESCRIPTION
Just before the unit tests are run by Jenkins, check the format of the code. If the format is incorrect, the job will fail.

In addition, right now, the following warnings are output when running `npm run lint`.
```
/home/massakam/github/pulsar-client-node/tests/end_to_end.test.js
   59:21  warning  Unexpected `await` inside a loop  no-await-in-loop
  203:21  warning  Unexpected `await` inside a loop  no-await-in-loop
  269:29  warning  Unexpected `await` inside a loop  no-await-in-loop
  274:29  warning  Unexpected `await` inside a loop  no-await-in-loop
  322:21  warning  Unexpected `await` inside a loop  no-await-in-loop

? 5 problems (0 errors, 5 warnings)
```
These warnings can be ignored in the test code, so I modified `.eslintrc.json`.