### PR TITLE
Add support for passing `log` function when creating client

### DIFF
--- a/src/Client.h
+++ b/src/Client.h
@@ -23,15 +23,33 @@
 #include <napi.h>
 #include <pulsar/c/client.h>
 
+struct LogMessage {
+  pulsar_logger_level_t level;
+  std::string file;
+  int line;
+  std::string message;
+
+  LogMessage(pulsar_logger_level_t level, std::string file, int line, std::string message)
+      : level(level), file(file), line(line), message(message) {}
+};
+
+struct LogCallback {
+  Napi::ThreadSafeFunction callback;
+};
+
+void LogMessage(pulsar_logger_level_t level, const char *file, int line, const char *message, void *ctx);
+
 class Client : public Napi::ObjectWrap<Client> {
  public:
   static Napi::Object Init(Napi::Env env, Napi::Object exports);
+
   Client(const Napi::CallbackInfo &info);
   ~Client();
 
  private:
   static Napi::FunctionReference constructor;
   pulsar_client_t *cClient;
+  LogCallback *logCallback;
 
   Napi::Value CreateProducer(const Napi::CallbackInfo &info);
   Napi::Value Subscribe(const Napi::CallbackInfo &info);


### PR DESCRIPTION
Issue: https://github.com/apache/pulsar-client-node/issues/9

```
var client = new Pulsar.Client({
  log: function(level /* typescript enum */, file, line, message) {
      // log with console.log or other logging implementation
  }
})
```

If no log function is passed, it will use default logging.

I am new to NAPI and C++, I am open for feedback and to learn!