### PR TITLE
Consumer with message listener dies after some time

### DIFF
--- a/src/Consumer.h
+++ b/src/Consumer.h
@@ -23,6 +23,7 @@
 #include <napi.h>
 #include <pulsar/c/client.h>
 #include "ConsumerConfig.h"
+#include "MessageListener.h"
 
 class Consumer : public Napi::ObjectWrap<Consumer> {
  public:

--- a/src/ConsumerConfig.cc
+++ b/src/ConsumerConfig.cc
@@ -46,38 +46,11 @@ static const std::map<std::string, pulsar_consumer_type> SUBSCRIPTION_TYPE = {
 static const std::map<std::string, initial_position> INIT_POSITION = {
     {"Latest", initial_position_latest}, {"Earliest", initial_position_earliest}};
 
-struct MessageListenerProxyData {
-  std::shared_ptr<CConsumerWrapper> consumerWrapper;
-  pulsar_message_t *cMessage;
-
-  MessageListenerProxyData(std::shared_ptr<CConsumerWrapper> consumerWrapper, pulsar_message_t *cMessage)
-      : consumerWrapper(consumerWrapper), cMessage(cMessage) {}
-};
-
-void MessageListenerProxy(Napi::Env env, Napi::Function jsCallback, MessageListenerProxyData *data) {
-  Napi::Object msg = Message::NewInstance({}, data->cMessage);
-  Napi::Object consumerObj = Consumer::constructor.New({});
-  Consumer *consumer = Consumer::Unwrap(consumerObj);
-  consumer->SetCConsumer(std::move(data->consumerWrapper));
-  delete data;
-  jsCallback.Call({msg, consumerObj});
-}
-
-void MessageListener(pulsar_consumer_t *cConsumer, pulsar_message_t *cMessage, void *ctx) {
-  ListenerCallback *listenerCallback = (ListenerCallback *)ctx;
-  if (listenerCallback->callback.Acquire() != napi_ok) {
-    return;
-  };
-  MessageListenerProxyData *dataPtr =
-      new MessageListenerProxyData(listenerCallback->consumerWrapper, cMessage);
-  listenerCallback->callback.BlockingCall(dataPtr, MessageListenerProxy);
-  listenerCallback->callback.Release();
-}
-
 void FinalizeListenerCallback(Napi::Env env, ListenerCallback *cb, void *) { delete cb; }
 
 ConsumerConfig::ConsumerConfig(const Napi::Object &consumerConfig,
-                               std::shared_ptr<CConsumerWrapper> consumerWrapper)
+                               std::shared_ptr<CConsumerWrapper> consumerWrapper,
+                               pulsar_message_listener messageListener)
     : topic(""), subscription(""), ackTimeoutMs(0), nAckRedeliverTimeoutMs(60000), listener(nullptr) {
   this->cConsumerConfig = pulsar_consumer_configuration_create();
 
@@ -156,12 +129,11 @@ ConsumerConfig::ConsumerConfig(const Napi::Object &consumerConfig,
 
   if (consumerConfig.Has(CFG_LISTENER) && consumerConfig.Get(CFG_LISTENER).IsFunction()) {
     this->listener = new ListenerCallback();
-    this->listener->consumerWrapper = consumerWrapper;
     Napi::ThreadSafeFunction callback = Napi::ThreadSafeFunction::New(
         consumerConfig.Env(), consumerConfig.Get(CFG_LISTENER).As<Napi::Function>(), "Listener Callback", 1,
         1, (void *)NULL, FinalizeListenerCallback, listener);
     this->listener->callback = std::move(callback);
-    pulsar_consumer_configuration_set_message_listener(this->cConsumerConfig, &MessageListener,
+    pulsar_consumer_configuration_set_message_listener(this->cConsumerConfig, messageListener,
                                                        this->listener);
   }
 

--- a/src/MessageListener.h
+++ b/src/MessageListener.h
@@ -17,34 +17,23 @@
  * under the License.
  */
 
-#ifndef CONSUMER_CONFIG_H
-#define CONSUMER_CONFIG_H
+#ifndef MESSAGELISTENER_H
+#define MESSAGELISTENER_H
 
-#include <pulsar/c/consumer_configuration.h>
-#include "MessageListener.h"
+#include <napi.h>
+#include <pulsar/c/client.h>
 
-#define MIN_ACK_TIMEOUT_MILLIS 10000
+struct CConsumerWrapper {
+  pulsar_consumer_t *cConsumer;
+  CConsumerWrapper();
+  ~CConsumerWrapper();
+};
 
-class ConsumerConfig {
- public:
-  ConsumerConfig(const Napi::Object &consumerConfig, std::shared_ptr<CConsumerWrapper> consumerWrapper,
-                 pulsar_message_listener messageListener);
-  ~ConsumerConfig();
-  pulsar_consumer_configuration_t *GetCConsumerConfig();
-  std::string GetTopic();
-  std::string GetSubscription();
-  int64_t GetAckTimeoutMs();
-  int64_t GetNAckRedeliverTimeoutMs();
+struct ListenerCallback {
+  Napi::ThreadSafeFunction callback;
 
-  ListenerCallback *GetListenerCallback();
-
- private:
-  pulsar_consumer_configuration_t *cConsumerConfig;
-  std::string topic;
-  std::string subscription;
-  int64_t ackTimeoutMs;
-  int64_t nAckRedeliverTimeoutMs;
-  ListenerCallback *listener;
+  // Using consumer as void* since the ListenerCallback is shared between Config and Consumer.
+  void *consumer;
 };
 
 #endif


### PR DESCRIPTION
This PR:
- Moves message listener to consumer
- Use a single consumer instance

**Reproduction steps:**
1. Run this code
```javascript
const Pulsar = require('pulsar-client');

(async () => {
  // Create a client
  const client = new Pulsar.Client({
    serviceUrl: 'pulsar://localhost:6650'
  });

  // Create a consumer
  const consumer = await client.subscribe({
    topic: 'persistent://public/default/my-topic',
    subscription: 'sub1',
    subscriptionType: 'Shared',
    ackTimeoutMs: 10000,
    listener: function(msg, consumerArg) {
      console.log(new Date().toLocaleString(), msg.getData().toString());
      consumerArg.acknowledge(msg);
    }
  });

  /*
   * Those lines are commented, because they re-produce the issue.
   * Since they are commented, there is no active reference for the consumer being created
   */
  //await consumer.close();
  //await client.close();

})();
```
2. Wait some time, in this time I ran `examples/producer.js`
3. Consumer will die

Logs:
```
2020-03-27 14:41:05.065 INFO  Client:88 | Subscribing on Topic :persistent://public/default/my-topic
2020-03-27 14:41:05.066 INFO  ConnectionPool:85 | Created connection for pulsar://localhost:6650
2020-03-27 14:41:05.067 INFO  ClientConnection:330 | [127.0.0.1:51556 -> 127.0.0.1:6650] Connected to broker
2020-03-27 14:41:05.069 INFO  HandlerBase:53 | [persistent://public/default/my-topic, sub1, 0] Getting connection from pool
2020-03-27 14:41:05.071 INFO  ConsumerImpl:170 | [persistent://public/default/my-topic, sub1, 0] Created consumer on broker [127.0.0.1:51556 -> 127.0.0.1:6650]
3/27/2020, 2:41:05 PM my-message-0
3/27/2020, 2:41:05 PM my-message-1
3/27/2020, 2:41:05 PM my-message-3
3/27/2020, 2:41:05 PM my-message-4
3/27/2020, 2:41:05 PM my-message-2
3/27/2020, 2:41:05 PM my-message-5
3/27/2020, 2:41:05 PM my-message-6
3/27/2020, 2:41:05 PM my-message-7
3/27/2020, 2:41:05 PM my-message-8
3/27/2020, 2:41:05 PM my-message-9
2020-03-27 14:41:13.184 WARN  ConsumerImpl:99 | [persistent://public/default/my-topic, sub1, 0] Destroyed consumer which was not properly closed
```

I pressed `Ctrl+C` to close the process and those are the following logs:
```
2020-03-27 14:41:19.922 INFO  ClientConnection:1349 | [127.0.0.1:51556 -> 127.0.0.1:6650] Connection closed
2020-03-27 14:41:19.922 INFO  ClientConnection:235 | [127.0.0.1:51556 -> 127.0.0.1:6650] Destroyed connection
[1]    99522 segmentation fault  node examples/consumer.js
```
