### PR TITLE
Create reference for client

### DIFF
--- a/src/Client.cc
+++ b/src/Client.cc
@@ -151,6 +151,7 @@ Client::Client(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Client>(info) 
 
   this->cClient = pulsar_client_create(serviceUrl.Utf8Value().c_str(), cClientConfig);
   pulsar_client_configuration_free(cClientConfig);
+  this->Ref();
 }
 
 Client::~Client() {
@@ -218,6 +219,8 @@ class ClientCloseWorker : public Napi::AsyncWorker {
 };
 
 Napi::Value Client::Close(const Napi::CallbackInfo &info) {
+  this->Unref();
+
   Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(info.Env());
   ClientCloseWorker *wk = new ClientCloseWorker(deferred, this->cClient);
   wk->Queue();


### PR DESCRIPTION
Since we don’t have reference for the client, v8 can garbage collect this instance, which can cause the next code:

```
const Pulsar = require('pulsar-client');

(async () => {
  // Create a client
  const client = new Pulsar.Client({
    serviceUrl: 'pulsar://localhost:6650'
  });

  // Create a producer
  const producer = await client.createProducer({
    topic: 'persistent://public/default/my-topic',
    sendTimeoutMs: 30000,
    batchingEnabled: true,
  });

  let i =0;
  async function produceMessage() {
    i = i + 1;

    const msg = `my-message-${i}`;
    const ret = await producer.send({
      data: Buffer.from(msg),
    });
    console.log(`Sent message: ${msg}`);
    console.log(ret);

    setTimeout(produceMessage, 1000);
  }

  produceMessage();
})();
```

To close the connection suddenly and fail the producer.


Fixes: https://github.com/apache/pulsar-client-node/issues/78
