### PR TITLE
Fix consumer double close

### DIFF
--- a/src/Consumer.h
+++ b/src/Consumer.h
@@ -34,6 +34,7 @@ class Consumer : public Napi::ObjectWrap<Consumer> {
   ~Consumer();
   void SetCConsumer(std::shared_ptr<CConsumerWrapper> cConsumer);
   void SetListenerCallback(ListenerCallback *listener);
+  void Cleanup();
 
  private:
   std::shared_ptr<CConsumerWrapper> wrapper;

--- a/tests/consumer.test.js
+++ b/tests/consumer.test.js
@@ -87,5 +87,22 @@ const Pulsar = require('../index.js');
         })).rejects.toThrow('NAck timeout should be greater than or equal to zero');
       });
     });
+
+    describe('Close', () => {
+      test('throws error on subsequent calls to close', async () => {
+        const consumer = await client.subscribe({
+          topic: 'persistent://public/default/my-topic',
+          subscription: 'sub1',
+          subscriptionType: 'Shared',
+          // Test with listener since it changes the flow of close
+          // and reproduces an issue
+          listener() {},
+        });
+
+        await expect(consumer.close()).resolves.toEqual(null);
+
+        await expect(consumer.close()).rejects.toThrow('Failed to close consumer: AlreadyClosed');
+      });
+    });
   });
 })();


### PR DESCRIPTION
Fixes issue raised here: https://github.com/apache/pulsar-client-node/issues/62#issuecomment-612976617

We do `Unref` more than once in the old code, now we do `Unref` only if the consumer is closed.