### PR TITLE
Fix Cleanup Listener

### DIFF
--- a/src/Consumer.cc
+++ b/src/Consumer.cc
@@ -289,9 +289,15 @@ class ConsumerCloseWorker : public Napi::AsyncWorker {
 
 void Consumer::Cleanup() {
   if (this->listener) {
-    this->Unref();
-    this->listener = nullptr;
+    this->CleanupListener();
   }
+}
+
+void Consumer::CleanupListener() {
+  pulsar_consumer_pause_message_listener(this->wrapper->cConsumer);
+  this->Unref();
+  this->listener->callback.Release();
+  this->listener = nullptr;
 }
 
 Napi::Value Consumer::Close(const Napi::CallbackInfo &info) {
@@ -303,7 +309,6 @@ Napi::Value Consumer::Close(const Napi::CallbackInfo &info) {
 
 Consumer::~Consumer() {
   if (this->listener) {
-    pulsar_consumer_pause_message_listener(this->wrapper->cConsumer);
-    this->listener->callback.Release();
+    this->CleanupListener();
   }
 }

--- a/src/Consumer.h
+++ b/src/Consumer.h
@@ -35,6 +35,7 @@ class Consumer : public Napi::ObjectWrap<Consumer> {
   void SetCConsumer(std::shared_ptr<CConsumerWrapper> cConsumer);
   void SetListenerCallback(ListenerCallback *listener);
   void Cleanup();
+  void CleanupListener();
 
  private:
   std::shared_ptr<CConsumerWrapper> wrapper;


### PR DESCRIPTION
### Motivation
When the following code is executed, the node process is not finished in spite of consuming all messages and closing the consumer and client.

```
const Pulsar = require('pulsar-client');

(async () => {
  const client = new Pulsar.Client({
    serviceUrl: 'pulsar://localhost:6650',
  });
  let received = 0;
  let finish;
  const finishPromise = new Promise((resolve) => {
    finish = resolve;
  });

  const consumer = await client.subscribe({
    topic: 'persistent://public/default/my-topic',
    subscription: 'sub1',
    listener: (msg, msgConsumer) => {
      const data = msg.getData().toString();
      console.log(data);
      msgConsumer.acknowledge(msg);
      received += 1;
      if (received === 10) finish();
    },
  });

  await finishPromise;
  await consumer.close();
  await client.close();
})();
```

It seems that this happens because the registered listener function is not released.
https://github.com/apache/pulsar-client-node/blob/master/src/Consumer.cc#L307 
`this->listener->callback.Release();` is not executed because `this->listener` becomes `nullptr` when consumers are closed.

### Modification
Fix so that the registered listener function is released when the consumer is closed.