### PR TITLE
Updated compatibility table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Compatibility between each version of the Node.js client and the C++ client is a
 |----------------|----------------|
 | 1.0.0          | 2.3.0 or later |
 | 1.1.0          | 2.4.0 or later |
+| 1.2.0          | 2.5.0 or later |
 
 If an incompatible version of the C++ client is installed, you may fail to build or run this library.
 


### PR DESCRIPTION
The Node.js library version 1.2.0 requires the C++ library 2.5.0 or later.