### PR TITLE
Adds Pattern/RegEx Support to Consumer

### DIFF
--- a/src/Consumer.cc
+++ b/src/Consumer.cc
@@ -106,8 +106,10 @@ class ConsumerNewInstanceWorker : public Napi::AsyncWorker {
   ~ConsumerNewInstanceWorker() {}
   void Execute() {
     const std::string &topic = this->consumerConfig->GetTopic();
-    if (topic.empty()) {
-      SetError(std::string("Topic is required and must be specified as a string when creating consumer"));
+    const std::string &topicsPattern = this->consumerConfig->GetTopicsPattern();
+    if (topic.empty() && topicsPattern.empty()) {
+      SetError(std::string(
+          "Topic or topicsPattern is required and must be specified as a string when creating consumer"));
       return;
     }
     const std::string &subscription = this->consumerConfig->GetSubscription();
@@ -131,9 +133,8 @@ class ConsumerNewInstanceWorker : public Napi::AsyncWorker {
     }
 
     this->done = false;
-    const std::string &mode = this->consumerConfig->GetMode();
-    if (mode == "Pattern") {
-      pulsar_client_subscribe_pattern_async(this->cClient, topic.c_str(), subscription.c_str(),
+    if (topic.empty()) {
+      pulsar_client_subscribe_pattern_async(this->cClient, topicsPattern.c_str(), subscription.c_str(),
                                             this->consumerConfig->GetCConsumerConfig(),
                                             &ConsumerNewInstanceWorker::subscribeCallback, (void *)this);
     } else {

--- a/src/ConsumerConfig.cc
+++ b/src/ConsumerConfig.cc
@@ -25,7 +25,7 @@
 #include <map>
 
 static const std::string CFG_TOPIC = "topic";
-static const std::string CFG_SUBSCRIPTION_MODE = "subscriptionMode";
+static const std::string CFG_TOPICS_PATTERN = "topicsPattern";
 static const std::string CFG_SUBSCRIPTION = "subscription";
 static const std::string CFG_SUBSCRIPTION_TYPE = "subscriptionType";
 static const std::string CFG_INIT_POSITION = "subscriptionInitialPosition";
@@ -53,7 +53,7 @@ ConsumerConfig::ConsumerConfig(const Napi::Object &consumerConfig,
                                std::shared_ptr<CConsumerWrapper> consumerWrapper,
                                pulsar_message_listener messageListener)
     : topic(""),
-      mode(""),
+      topicsPattern(""),
       subscription(""),
       ackTimeoutMs(0),
       nAckRedeliverTimeoutMs(60000),
@@ -64,8 +64,8 @@ ConsumerConfig::ConsumerConfig(const Napi::Object &consumerConfig,
     this->topic = consumerConfig.Get(CFG_TOPIC).ToString().Utf8Value();
   }
 
-  if (consumerConfig.Has(CFG_SUBSCRIPTION_MODE) && consumerConfig.Get(CFG_SUBSCRIPTION_MODE).IsString()) {
-    this->mode = consumerConfig.Get(CFG_SUBSCRIPTION_MODE).ToString().Utf8Value();
+  if (consumerConfig.Has(CFG_TOPICS_PATTERN) && consumerConfig.Get(CFG_TOPICS_PATTERN).IsString()) {
+    this->topicsPattern = consumerConfig.Get(CFG_TOPICS_PATTERN).ToString().Utf8Value();
   }
 
   if (consumerConfig.Has(CFG_SUBSCRIPTION) && consumerConfig.Get(CFG_SUBSCRIPTION).IsString()) {
@@ -165,7 +165,7 @@ ConsumerConfig::~ConsumerConfig() {
 pulsar_consumer_configuration_t *ConsumerConfig::GetCConsumerConfig() { return this->cConsumerConfig; }
 
 std::string ConsumerConfig::GetTopic() { return this->topic; }
-std::string ConsumerConfig::GetMode() { return this->mode; }
+std::string ConsumerConfig::GetTopicsPattern() { return this->topicsPattern; }
 std::string ConsumerConfig::GetSubscription() { return this->subscription; }
 ListenerCallback *ConsumerConfig::GetListenerCallback() {
   ListenerCallback *cb = this->listener;

--- a/src/ConsumerConfig.cc
+++ b/src/ConsumerConfig.cc
@@ -25,6 +25,7 @@
 #include <map>
 
 static const std::string CFG_TOPIC = "topic";
+static const std::string CFG_SUBSCRIPTION_MODE = "subscriptionMode";
 static const std::string CFG_SUBSCRIPTION = "subscription";
 static const std::string CFG_SUBSCRIPTION_TYPE = "subscriptionType";
 static const std::string CFG_INIT_POSITION = "subscriptionInitialPosition";
@@ -51,11 +52,20 @@ void FinalizeListenerCallback(Napi::Env env, ListenerCallback *cb, void *) { del
 ConsumerConfig::ConsumerConfig(const Napi::Object &consumerConfig,
                                std::shared_ptr<CConsumerWrapper> consumerWrapper,
                                pulsar_message_listener messageListener)
-    : topic(""), subscription(""), ackTimeoutMs(0), nAckRedeliverTimeoutMs(60000), listener(nullptr) {
+    : topic(""),
+      mode(""),
+      subscription(""),
+      ackTimeoutMs(0),
+      nAckRedeliverTimeoutMs(60000),
+      listener(nullptr) {
   this->cConsumerConfig = pulsar_consumer_configuration_create();
 
   if (consumerConfig.Has(CFG_TOPIC) && consumerConfig.Get(CFG_TOPIC).IsString()) {
     this->topic = consumerConfig.Get(CFG_TOPIC).ToString().Utf8Value();
+  }
+
+  if (consumerConfig.Has(CFG_SUBSCRIPTION_MODE) && consumerConfig.Get(CFG_SUBSCRIPTION_MODE).IsString()) {
+    this->mode = consumerConfig.Get(CFG_SUBSCRIPTION_MODE).ToString().Utf8Value();
   }
 
   if (consumerConfig.Has(CFG_SUBSCRIPTION) && consumerConfig.Get(CFG_SUBSCRIPTION).IsString()) {
@@ -155,6 +165,7 @@ ConsumerConfig::~ConsumerConfig() {
 pulsar_consumer_configuration_t *ConsumerConfig::GetCConsumerConfig() { return this->cConsumerConfig; }
 
 std::string ConsumerConfig::GetTopic() { return this->topic; }
+std::string ConsumerConfig::GetMode() { return this->mode; }
 std::string ConsumerConfig::GetSubscription() { return this->subscription; }
 ListenerCallback *ConsumerConfig::GetListenerCallback() {
   ListenerCallback *cb = this->listener;

--- a/src/ConsumerConfig.h
+++ b/src/ConsumerConfig.h
@@ -32,6 +32,7 @@ class ConsumerConfig {
   ~ConsumerConfig();
   pulsar_consumer_configuration_t *GetCConsumerConfig();
   std::string GetTopic();
+  std::string GetMode();
   std::string GetSubscription();
   int64_t GetAckTimeoutMs();
   int64_t GetNAckRedeliverTimeoutMs();
@@ -41,6 +42,7 @@ class ConsumerConfig {
  private:
   pulsar_consumer_configuration_t *cConsumerConfig;
   std::string topic;
+  std::string mode;
   std::string subscription;
   int64_t ackTimeoutMs;
   int64_t nAckRedeliverTimeoutMs;

--- a/src/ConsumerConfig.h
+++ b/src/ConsumerConfig.h
@@ -32,7 +32,7 @@ class ConsumerConfig {
   ~ConsumerConfig();
   pulsar_consumer_configuration_t *GetCConsumerConfig();
   std::string GetTopic();
-  std::string GetMode();
+  std::string GetTopicsPattern();
   std::string GetSubscription();
   int64_t GetAckTimeoutMs();
   int64_t GetNAckRedeliverTimeoutMs();
@@ -42,7 +42,7 @@ class ConsumerConfig {
  private:
   pulsar_consumer_configuration_t *cConsumerConfig;
   std::string topic;
-  std::string mode;
+  std::string topicsPattern;
   std::string subscription;
   int64_t ackTimeoutMs;
   int64_t nAckRedeliverTimeoutMs;

--- a/tests/consumer.test.js
+++ b/tests/consumer.test.js
@@ -31,7 +31,7 @@ const Pulsar = require('../index.js');
           subscription: 'sub1',
           ackTimeoutMs: 10000,
           nAckRedeliverTimeoutMs: 60000,
-        })).rejects.toThrow('Topic is required and must be specified as a string when creating consumer');
+        })).rejects.toThrow('Topic or topicsPattern is required and must be specified as a string when creating consumer');
       });
 
       test('Not String Topic', async () => {
@@ -40,7 +40,16 @@ const Pulsar = require('../index.js');
           subscription: 'sub1',
           ackTimeoutMs: 10000,
           nAckRedeliverTimeoutMs: 60000,
-        })).rejects.toThrow('Topic is required and must be specified as a string when creating consumer');
+        })).rejects.toThrow('Topic or topicsPattern is required and must be specified as a string when creating consumer');
+      });
+
+      test('Not String TopicsPattern', async () => {
+        await expect(client.subscribe({
+          topicsPattern: 0,
+          subscription: 'sub1',
+          ackTimeoutMs: 10000,
+          nAckRedeliverTimeoutMs: 60000,
+        })).rejects.toThrow('Topic or topicsPattern is required and must be specified as a string when creating consumer');
       });
 
       test('No Subscription', async () => {

--- a/tests/end_to_end.test.js
+++ b/tests/end_to_end.test.js
@@ -552,7 +552,7 @@ const Pulsar = require('../index.js');
 
       const topic1 = 'persistent://public/default/produce-abcdef';
       const topic2 = 'persistent://public/default/produce-abczef';
-      const topicPattern = 'persistent://public/default/produce-abc[a-z]ef';
+      const topicsPattern = 'persistent://public/default/produce-abc[a-z]ef';
       const producer1 = await client.createProducer({
         topic: topic1,
         sendTimeoutMs: 30000,
@@ -567,8 +567,7 @@ const Pulsar = require('../index.js');
       expect(producer2).not.toBeNull();
 
       const consumer = await client.subscribe({
-        topic: topicPattern,
-        subscriptionMode: 'Pattern',
+        topicsPattern,
         subscription: 'sub',
         subscriptionType: 'Shared',
       });


### PR DESCRIPTION
Implements a quick-and-dirty hack to get RegEx support working for topics in consumers by spinning using ```std::this_thread::yield()``` in ```Napi::AsyncWorker```'s ```Execute``` function while waiting for callbacks. This allows the ```pulsar_client_subscribe_pattern_async``` and ```pulsar_client_subscribe_async``` functions to be used from the C++ library.