### PR TITLE
Adds getProducerName and getTopic to Producer

### DIFF
--- a/src/Producer.cc
+++ b/src/Producer.cc
@@ -30,7 +30,8 @@ void Producer::Init(Napi::Env env, Napi::Object exports) {
   Napi::Function func =
       DefineClass(env, "Producer",
                   {InstanceMethod("send", &Producer::Send), InstanceMethod("flush", &Producer::Flush),
-                   InstanceMethod("close", &Producer::Close)});
+                   InstanceMethod("close", &Producer::Close),
+                   InstanceMethod("getProducerName", &Producer::GetProducerName)});
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -181,6 +182,11 @@ Napi::Value Producer::Close(const Napi::CallbackInfo &info) {
   ProducerCloseWorker *wk = new ProducerCloseWorker(deferred, this->cProducer);
   wk->Queue();
   return deferred.Promise();
+}
+
+Napi::Value Producer::GetProducerName(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  return Napi::String::New(env, pulsar_producer_get_producer_name(this->cProducer));
 }
 
 Producer::~Producer() { pulsar_producer_free(this->cProducer); }

--- a/src/Producer.cc
+++ b/src/Producer.cc
@@ -31,7 +31,8 @@ void Producer::Init(Napi::Env env, Napi::Object exports) {
       DefineClass(env, "Producer",
                   {InstanceMethod("send", &Producer::Send), InstanceMethod("flush", &Producer::Flush),
                    InstanceMethod("close", &Producer::Close),
-                   InstanceMethod("getProducerName", &Producer::GetProducerName)});
+                   InstanceMethod("getProducerName", &Producer::GetProducerName),
+                   InstanceMethod("getTopic", &Producer::GetTopic)});
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -187,6 +188,11 @@ Napi::Value Producer::Close(const Napi::CallbackInfo &info) {
 Napi::Value Producer::GetProducerName(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   return Napi::String::New(env, pulsar_producer_get_producer_name(this->cProducer));
+}
+
+Napi::Value Producer::GetTopic(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  return Napi::String::New(env, pulsar_producer_get_topic(this->cProducer));
 }
 
 Producer::~Producer() { pulsar_producer_free(this->cProducer); }

--- a/src/Producer.h
+++ b/src/Producer.h
@@ -38,6 +38,7 @@ class Producer : public Napi::ObjectWrap<Producer> {
   Napi::Value Send(const Napi::CallbackInfo &info);
   Napi::Value Flush(const Napi::CallbackInfo &info);
   Napi::Value Close(const Napi::CallbackInfo &info);
+  Napi::Value GetProducerName(const Napi::CallbackInfo &info);
 };
 
 #endif

--- a/src/Producer.h
+++ b/src/Producer.h
@@ -39,6 +39,7 @@ class Producer : public Napi::ObjectWrap<Producer> {
   Napi::Value Flush(const Napi::CallbackInfo &info);
   Napi::Value Close(const Napi::CallbackInfo &info);
   Napi::Value GetProducerName(const Napi::CallbackInfo &info);
+  Napi::Value GetTopic(const Napi::CallbackInfo &info);
 };
 
 #endif

--- a/tests/producer.test.js
+++ b/tests/producer.test.js
@@ -57,12 +57,22 @@ const Pulsar = require('../index.js');
         })).rejects.toThrow('Failed to create producer: ConnectError');
       });
 
-      test('Producer Name', async () => {
+      test('Automatic Producer Name', async () => {
         const producer = await client.createProducer({
           topic: 'persistent://public/default/topic',
         });
 
         expect(typeof producer.getProducerName()).toBe('string');
+        await producer.close();
+      });
+
+      test('Explicit Producer Name', async () => {
+        const producer = await client.createProducer({
+          topic: 'persistent://public/default/topic',
+          producerName: 'test-producer',
+        });
+
+        expect(producer.getProducerName()).toBe('test-producer');
         await producer.close();
       });
 

--- a/tests/producer.test.js
+++ b/tests/producer.test.js
@@ -63,6 +63,16 @@ const Pulsar = require('../index.js');
         });
 
         expect(typeof producer.getProducerName()).toBe('string');
+        await producer.close();
+      });
+
+      test('Topic Name', async () => {
+        const producer = await client.createProducer({
+          topic: 'persistent://public/default/topic',
+        });
+
+        expect(producer.getTopic()).toBe('persistent://public/default/topic');
+        await producer.close();
       });
     });
   });

--- a/tests/producer.test.js
+++ b/tests/producer.test.js
@@ -56,6 +56,14 @@ const Pulsar = require('../index.js');
           batchingEnabled: true,
         })).rejects.toThrow('Failed to create producer: ConnectError');
       });
+
+      test('Producer Name', async () => {
+        const producer = await client.createProducer({
+          topic: 'persistent://public/default/topic',
+        });
+
+        expect(typeof producer.getProducerName()).toBe('string');
+      });
     });
   });
 })();


### PR DESCRIPTION
It simply hooks up `pulsar_producer_get_topic` and `pulsar_producer_get_producer_name` so the JS client can have access to these values.