### PR TITLE
feature: allow messages and producers to handle int64 sequences

### DIFF
--- a/src/Message.cc
+++ b/src/Message.cc
@@ -20,6 +20,7 @@
 #include "Message.h"
 #include "MessageId.h"
 #include <pulsar/c/message.h>
+#include <string>
 
 static const std::string CFG_DATA = "data";
 static const std::string CFG_PROPS = "properties";
@@ -174,6 +175,11 @@ pulsar_message_t *Message::BuildMessage(Napi::Object conf) {
   if (conf.Has(CFG_SEQUENCE_ID) && conf.Get(CFG_SEQUENCE_ID).IsNumber()) {
     Napi::Number sequenceId = conf.Get(CFG_SEQUENCE_ID).ToNumber();
     pulsar_message_set_sequence_id(cMessage, sequenceId.Int64Value());
+  }
+
+  if (conf.Has(CFG_SEQUENCE_ID) && conf.Get(CFG_SEQUENCE_ID).IsString()) {
+    std::string sequenceId = conf.Get(CFG_SEQUENCE_ID).ToString().Utf8Value();
+    pulsar_message_set_sequence_id(cMessage, std::strtoll(sequenceId.c_str(), 0, 10));
   }
 
   if (conf.Has(CFG_PARTITION_KEY) && conf.Get(CFG_PARTITION_KEY).IsString()) {

--- a/src/Producer.cc
+++ b/src/Producer.cc
@@ -22,6 +22,8 @@
 #include "Message.h"
 #include <pulsar/c/result.h>
 #include <memory>
+#include <string>
+
 Napi::FunctionReference Producer::constructor;
 
 void Producer::Init(Napi::Env env, Napi::Object exports) {
@@ -32,7 +34,8 @@ void Producer::Init(Napi::Env env, Napi::Object exports) {
                   {InstanceMethod("send", &Producer::Send), InstanceMethod("flush", &Producer::Flush),
                    InstanceMethod("close", &Producer::Close),
                    InstanceMethod("getProducerName", &Producer::GetProducerName),
-                   InstanceMethod("getTopic", &Producer::GetTopic)});
+                   InstanceMethod("getTopic", &Producer::GetTopic),
+                   InstanceMethod("getLastSequenceId", &Producer::GetLastSequenceId)});
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -193,6 +196,12 @@ Napi::Value Producer::GetProducerName(const Napi::CallbackInfo &info) {
 Napi::Value Producer::GetTopic(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   return Napi::String::New(env, pulsar_producer_get_topic(this->cProducer));
+}
+
+Napi::Value Producer::GetLastSequenceId(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  int64_t lastSequenceId = pulsar_producer_get_last_sequence_id(this->cProducer);
+  return Napi::String::New(env, std::to_string(lastSequenceId));
 }
 
 Producer::~Producer() { pulsar_producer_free(this->cProducer); }

--- a/src/Producer.h
+++ b/src/Producer.h
@@ -40,6 +40,7 @@ class Producer : public Napi::ObjectWrap<Producer> {
   Napi::Value Close(const Napi::CallbackInfo &info);
   Napi::Value GetProducerName(const Napi::CallbackInfo &info);
   Napi::Value GetTopic(const Napi::CallbackInfo &info);
+  Napi::Value GetLastSequenceId(const Napi::CallbackInfo &info);
 };
 
 #endif

--- a/src/ProducerConfig.cc
+++ b/src/ProducerConfig.cc
@@ -19,6 +19,7 @@
 
 #include "ProducerConfig.h"
 #include <map>
+#include <string>
 
 static const std::string CFG_TOPIC = "topic";
 static const std::string CFG_PRODUCER_NAME = "producerName";
@@ -76,6 +77,12 @@ ProducerConfig::ProducerConfig(const Napi::Object& producerConfig) : topic("") {
   if (producerConfig.Has(CFG_INIT_SEQUENCE_ID) && producerConfig.Get(CFG_INIT_SEQUENCE_ID).IsNumber()) {
     int64_t initialSequenceId = producerConfig.Get(CFG_INIT_SEQUENCE_ID).ToNumber().Int64Value();
     pulsar_producer_configuration_set_initial_sequence_id(this->cProducerConfig, initialSequenceId);
+  }
+
+  if (producerConfig.Has(CFG_INIT_SEQUENCE_ID) && producerConfig.Get(CFG_INIT_SEQUENCE_ID).IsString()) {
+    std::string initialSequenceId = producerConfig.Get(CFG_INIT_SEQUENCE_ID).ToString().Utf8Value();
+    pulsar_producer_configuration_set_initial_sequence_id(this->cProducerConfig,
+                                                          std::strtoll(initialSequenceId.c_str(), 0, 10));
   }
 
   if (producerConfig.Has(CFG_MAX_PENDING) && producerConfig.Get(CFG_MAX_PENDING).IsNumber()) {

--- a/tests/producer.test.js
+++ b/tests/producer.test.js
@@ -84,6 +84,54 @@ const Pulsar = require('../index.js');
         expect(producer.getTopic()).toBe('persistent://public/default/topic');
         await producer.close();
       });
+
+      test('Sequence ID as Number', async () => {
+        const producer = await client.createProducer({
+          topic: 'persistent://public/default/sequence-id-number',
+          initialSequenceId: 100,
+        });
+
+        expect(producer.getLastSequenceId()).toEqual('100');
+
+        await producer.send({
+          data: Buffer.from('testing'),
+        });
+        await producer.flush();
+        expect(producer.getLastSequenceId()).toEqual('101');
+
+        await producer.send({
+          sequenceId: 105,
+          data: Buffer.from('testing'),
+        });
+        await producer.flush();
+        expect(producer.getLastSequenceId()).toEqual('105');
+
+        await producer.close();
+      });
+
+      test('Sequence ID as String', async () => {
+        const producer = await client.createProducer({
+          topic: 'persistent://public/default/sequence-id-string',
+          initialSequenceId: '100',
+        });
+
+        expect(producer.getLastSequenceId()).toEqual('100');
+
+        await producer.send({
+          data: Buffer.from('testing'),
+        });
+        await producer.flush();
+        expect(producer.getLastSequenceId()).toEqual('101');
+
+        await producer.send({
+          sequenceId: '105',
+          data: Buffer.from('testing'),
+        });
+        await producer.flush();
+        expect(producer.getLastSequenceId()).toEqual('105');
+
+        await producer.close();
+      });
     });
   });
 })();


### PR DESCRIPTION
* Allows the initial sequence ID to be passed as a string: `client.createProducer({initialSequenceId: '1234'})` so JS can send 64 bits integers encoded as string.
* Allows the message sequence ID to be passed as a string `producer.send({sequenceId: '1234'})` so JS can send 64 bits integers encoded as string.
* Implements `Producer.getLastSequenceId` which returns `Napi::String` since `Napi::Number` cannot be used for 64 bits integers.
* Closes #124 