### PR TITLE
Add definition of AthenzConfig

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -145,7 +145,19 @@ export class AuthenticationTls {
 }
 
 export class AuthenticationAthenz {
-  constructor(params: string);
+  constructor(params: string | AthenzConfig);
+}
+
+export interface AthenzConfig {
+  tenantDomain: string;
+  tenantService: string;
+  providerDomain: string;
+  privateKey: string;
+  ztsUrl: string;
+  keyId?: string;
+  principalHeader?: string;
+  roleHeader?: string;
+  tokenExpirationTime?: string;
 }
 
 export class AuthenticationToken {

--- a/tstest.ts
+++ b/tstest.ts
@@ -25,7 +25,19 @@ import Pulsar = require('./index');
     privateKeyPath: '/path/to/key.pem',
   });
 
-  const authAthenz: Pulsar.AuthenticationAthenz = new Pulsar.AuthenticationAthenz('{}');
+  const authAthenz1: Pulsar.AuthenticationAthenz = new Pulsar.AuthenticationAthenz('{}');
+
+  const authAthenz2: Pulsar.AuthenticationAthenz = new Pulsar.AuthenticationAthenz({
+    tenantDomain: 'athenz.tenant.domain',
+    tenantService: 'service',
+    providerDomain: 'athenz.provider.domain',
+    privateKey: 'file:///path/to/private.key',
+    ztsUrl: 'https://localhost:8443',
+    keyId: '0',
+    principalHeader: 'Athenz-Principal-Auth',
+    roleHeader: 'Athenz-Role-Auth',
+    tokenExpirationTime: '3600',
+  });
 
   const authToken: Pulsar.AuthenticationToken = new Pulsar.AuthenticationToken({
     token: 'foobar',
@@ -215,6 +227,14 @@ import Pulsar = require('./index');
 
 // Minimal parameters
 (async () => {
+  const authAthenz: Pulsar.AuthenticationAthenz = new Pulsar.AuthenticationAthenz({
+    tenantDomain: 'athenz.tenant.domain',
+    tenantService: 'service',
+    providerDomain: 'athenz.provider.domain',
+    privateKey: 'file:///path/to/private.key',
+    ztsUrl: 'https://localhost:8443',
+  });
+
   const client: Pulsar.Client = new Pulsar.Client({
     serviceUrl: 'pulsar://localhost:6650',
   });
@@ -257,6 +277,10 @@ import Pulsar = require('./index');
 
 // Missing required parameters
 (async () => {
+  // $ExpectError
+  const authAthenz: Pulsar.AuthenticationAthenz = new Pulsar.AuthenticationAthenz({
+  });
+
   // $ExpectError
   const client: Pulsar.Client = new Pulsar.Client({
   });


### PR DESCRIPTION
The constructor of the `AuthenticationAthenz` class can accept one string or object as an argument, but currently there is only a type definition for string. So I added a type definition to accept the object type argument.