### PR TITLE
Support Disable Replication

### DIFF
--- a/src/Message.cc
+++ b/src/Message.cc
@@ -29,6 +29,7 @@ static const std::string CFG_PARTITION_KEY = "partitionKey";
 static const std::string CFG_REPL_CLUSTERS = "replicationClusters";
 static const std::string CFG_DELIVER_AFTER = "deliverAfter";
 static const std::string CFG_DELIVER_AT = "deliverAt";
+static const std::string CFG_DISABLE_REPLICATION = "disableReplication";
 
 Napi::FunctionReference Message::constructor;
 
@@ -205,6 +206,13 @@ pulsar_message_t *Message::BuildMessage(Napi::Object conf) {
   if (conf.Has(CFG_DELIVER_AT) && conf.Get(CFG_DELIVER_AT).IsNumber()) {
     Napi::Number deliverAt = conf.Get(CFG_DELIVER_AT).ToNumber();
     pulsar_message_set_deliver_at(cMessage, deliverAt.Int64Value());
+  }
+
+  if (conf.Has(CFG_DISABLE_REPLICATION) && conf.Get(CFG_DISABLE_REPLICATION).IsBoolean()) {
+    Napi::Boolean disableReplication = conf.Get(CFG_DISABLE_REPLICATION).ToBoolean();
+    if (disableReplication.Value()) {
+      pulsar_message_disable_replication(cMessage, 1);
+    }
   }
   return cMessage;
 }


### PR DESCRIPTION
Support disable replication.

Because `disableReplication` is not working in pulsar-client-cpp 2.7.0 or previous version, needs 2.7.1 or later version. 
This bug was fixed in https://github.com/apache/pulsar/pull/9372