### PR TITLE
Use Buffer::Copy instead of Buffer::New

### DIFF
--- a/src/Message.cc
+++ b/src/Message.cc
@@ -102,7 +102,7 @@ Napi::Value Message::GetData(const Napi::CallbackInfo &info) {
   }
   void *data = const_cast<void *>(pulsar_message_get_data(this->cMessage));
   size_t size = (size_t)pulsar_message_get_length(this->cMessage);
-  return Napi::Buffer<char>::New(env, (char *)data, size);
+  return Napi::Buffer<char>::Copy(env, (char *)data, size);
 }
 
 Napi::Value Message::GetMessageId(const Napi::CallbackInfo &info) {


### PR DESCRIPTION
In our enviroment, sometimes we get following error.
```
#
# Fatal error in , line 0
# Check failed: result.second.
#
#
#
#FailureMessage Object: 0x7ffe7bd5eda0
 1: 0xa92851  [node]
 2: 0x1a1ac64 V8_Fatal(char const*, ...) [node]
 3: 0xe7e119 v8::internal::GlobalBackingStoreRegistry::Register(std::shared_ptr<v8::internal::BackingStore>) [node]
 4: 0xbc7e48 v8::ArrayBuffer::GetBackingStore() [node]
 5: 0x9e3a80 napi_get_typedarray_info [node]
 6: 0x7f815dd9f669 Message::GetData(Napi::CallbackInfo const&) [/root/pulsar-client-node/build/Release/Pulsar.node]
 7: 0x7f815dda3aa1 Napi::ObjectWrap<Message>::InstanceMethodCallbackWrapper(napi_env__*, napi_callback_info__*) [/root/pulsar-client-node/build/Release/Pulsar.node]
 8: 0x9da63f  [node]
 9: 0xc06acb  [node]
10: 0xc08076  [node]
11: 0xc086f6 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [node]
12: 0x1427159  [node]
Illegal instruction (core dumped)

```

## Modification
I use `Napi::Buffer<T>::Copy` instead of `Napi::Buffer<T>::New`.

## Steps to reproduce
One easy way to reproduce  is to call `msg::getData()` twice.
```
    const msg = await consumer.receive();
    console.log(msg.getData().toString());
    console.log(msg.getData().toString());
```

<br>
This issue occures on node 14 or above.
