### PR TITLE
Fix cflags_cc for gcc-4.9

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -28,8 +28,9 @@
   "targets": [
     {
       "target_name": "Pulsar",
+      "cflags_cc": ["-std=gnu++11"],
       "cflags!": ["-fno-exceptions"],
-      "cflags_cc!": ["-fno-exceptions"],
+      "cflags_cc!": ["-fno-exceptions", "-std=gnu++14", "-std=gnu++17"],
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")",
       ],


### PR DESCRIPTION
When compiling pulsar-client-node with gcc4.9 and node v16.5.0, build failed with following error.
```
g++: error: unrecognized command line option ‘-std=gnu++14’
make: *** [Release/obj.target/Pulsar/src/addon.o] Error 1
make: Leaving directory `/root/pulsar-client-node/build'
```

Gcc4.9 does not support `-std=gnu++14` option, but this option was added to common.gypi intead of `-std=gnu++1y` from node v16.2.0.
https://github.com/nodejs/node/blob/v16.2.0/common.gypi#L378

Also added `-std=gnu++17` option from node v17.1.0.
https://github.com/nodejs/node/blob/v17.1.0/common.gypi#L388

## Modification
Add `-std=gnu++11` option to `cflags_cc` and remove `-std=gnu++14/17` options from it because pulsar-client-node can be compiled with just `-std=gnu++11` option.