### PR TITLE
Add tarball files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ build/
 node_modules/
 report/
 .idea
+*.tar.gz
+*.tgz


### PR DESCRIPTION
Recently, the release process for the Node.js client has been modified and added a step to create a tarball of this repository.
```sh
# Archive the source files
$ git archive HEAD --prefix=pulsar-client-node-1.X.0/ --output pulsar-client-node-1.X.0.tar.gz
```
I added two file extensions to `.gitignore` to prevent this tarball from being committed.