### PR TITLE
Do not add license header to tarball file

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "file_types": [
       ".json",
       ".pem",
-      ".txt"
+      ".txt",
+      ".gz"
     ],
     "trailing_whitespace": "TRIM",
     "insert_license": true,


### PR DESCRIPTION
There is a step in [the release process](https://github.com/apache/pulsar-client-node/wiki/Release-process) to run `npm run license: addheader`, which will add the license header to the source file archive (pulsar-client-node-1.X.0.tar.gz) and corrupt the file.

To avoid this, I modified the setting so that the license header is not added to files with the file extension `.gz`.