### PR TITLE
Add a pulsar nodejs client document link to package.json/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,6 @@ $ npm install
 ```shell
 $ npm run build
 ```
+
+## Documentation
+* Please see https://pulsar.apache.org/docs/en/client-libraries-node for more details about the Pulsar Node.js client.  

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "type": "git",
     "url": "https://github.com/apache/pulsar-client-node.git"
   },
+  "homepage": "https://pulsar.apache.org/docs/en/client-libraries-node",
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "gypfile": true,


### PR DESCRIPTION
Currently, users can't find https://pulsar.apache.org/docs/en/client-libraries-node on [github](https://github.com/apache/pulsar-client-node) and [npmjs](https://www.npmjs.com/package/pulsar-client).