### PR TITLE
Add null check for consumer in MessageListenerProxy

### DIFF
--- a/src/Consumer.cc
+++ b/src/Consumer.cc
@@ -63,6 +63,8 @@ void MessageListenerProxy(Napi::Env env, Napi::Function jsCallback, MessageListe
   Consumer *consumer = data->consumer;
   delete data;
 
+  // `consumer` might be null in certain cases, segmentation fault might happend without this null check. We
+  // need to handle this rare case in future.
   if (consumer) {
     jsCallback.Call({msg, consumer->Value()});
   }

--- a/src/Consumer.cc
+++ b/src/Consumer.cc
@@ -63,7 +63,9 @@ void MessageListenerProxy(Napi::Env env, Napi::Function jsCallback, MessageListe
   Consumer *consumer = data->consumer;
   delete data;
 
-  jsCallback.Call({msg, consumer->Value()});
+  if (consumer) {
+    jsCallback.Call({msg, consumer->Value()});
+  }
 }
 
 void MessageListener(pulsar_consumer_t *rawConsumer, pulsar_message_t *rawMessage, void *ctx) {


### PR DESCRIPTION
There is a segmentation fault reported by a user.

> So, I recompiled the extension with `node-gyp rebuild --debug` then attached a debugger and it crashed because of this
>
> ```
> (gdb) l
> 60      void MessageListenerProxy(Napi::Env env, Napi::Function jsCallback, MessageListenerProxyData *data) {
> 61        Napi::Object msg = Message::NewInstance({}, data->cMessage);
> 62        Consumer *consumer = data->consumer;
> 63        delete data;
> 64
> 65        jsCallback.Call({msg, consumer->Value()});
> 66      }
> 67
> 68      void MessageListener(pulsar_consumer_t *cConsumer, pulsar_message_t *cMessage, void *ctx) {
> 69        ListenerCallback *listenerCallback = (ListenerCallback *)ctx;
> (gdb)
> ```
>
> On line 65, consumer is actually null 

The `consumer` field is assigned from `MessageListenerCallback` and the initial value is `nullptr`. This field could only be modified in `Consumer::SetListenerCallback`. I didn't look deeper into where it's invoked, but I think it's better to add the null check here for safety.