### PR TITLE
Split conditions between OS in binding.gyp

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,12 @@ brew info libpulsar
 
 ```shell
 # for example
+## Intel x86_64
 export PULSAR_CPP_DIR=/usr/local/Cellar/libpulsar/2.9.1_1
+
+## Apple Silicon and Homebrew since 3.0.0
+## cf. https://brew.sh/2021/02/05/homebrew-3.0.0/
+export PULSAR_CPP_DIR=/opt/homebrew/Cellar/libpulsar/2.9.1_1
 ```
 
 ### Install on Linux

--- a/binding.gyp
+++ b/binding.gyp
@@ -67,6 +67,9 @@
           "libraries": [
             "<(pulsar_cpp_dir)/lib/libpulsar.dylib"
           ],
+          "dependencies": [
+            "<!@(node -p \"require('node-addon-api').gyp\")"
+          ],
         }],
         ['OS=="win"', {
           "defines": [
@@ -102,7 +105,8 @@
               ]
             }
           ]
-        }, {  # 'OS!="win"'
+        }],
+        ['OS!="mac" and OS!="win"', {
           "libraries": [
             "-lpulsar",
           ],


### PR DESCRIPTION
# Motivation
On macOS and Apple Silicon, we can't build pulsar-client-node if using default environment variables like below.
https://github.com/apache/pulsar-client-node/issues/87#issuecomment-1157411697

```
% echo $LIBRARY_PATH


% PULSAR_CPP_DIR=/opt/homebrew/Cellar/libpulsar/2.10.0 npm install
...
ld: library not found for -lpulsar
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Debug/Pulsar.node] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/opt/homebrew/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
gyp ERR! stack     at ChildProcess.emit (node:events:527:28)
gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:291:12)
gyp ERR! System Darwin 21.5.0
gyp ERR! command "/opt/homebrew/Cellar/node/18.3.0/bin/node" "/opt/homebrew/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "build" "--fallback-to-build" "--debug" "--module=/Users/yumizush/src/pulsar-client-node/build/Release/libpulsar.node" "--module_name=libpulsar" "--module_path=/Users/yumizush/src/pulsar-client-node/build/Release" "--napi_version=8" "--node_abi_napi=napi" "--napi_build_version=0" "--node_napi_label=node-v108"
gyp ERR! cwd /Users/yumizush/src/pulsar-client-node
gyp ERR! node -v v18.3.0
gyp ERR! node-gyp -v v9.0.0
gyp ERR! not ok 
...
```

The root cause of the issue is clang tries to link `libpulsar` libraries through `-lpulsar` even if `OS==mac` .
Therefore, if you don't add `libpulsar` to the library path, then fail on any architectures.

I want to fix it.

# Modification
* Split target conditions between OS in `binding.gyp`
  - cf. https://github.com/nodejs/node-gyp/blob/v8.4.1/gyp/pylib/gyp/input.py#L1187-L1196
  - cf. https://docs.python.org/3/library/functions.html#compile
* Add an example script for macOS and Apple Silicon to the README.md
