### PR TITLE
Format ProducerConfig.cc

### DIFF
--- a/src/ProducerConfig.cc
+++ b/src/ProducerConfig.cc
@@ -100,8 +100,8 @@ ProducerConfig::ProducerConfig(const Napi::Object& producerConfig) : topic("") {
     int32_t maxPendingMessagesAcrossPartitions =
         producerConfig.Get(CFG_MAX_PENDING_ACROSS_PARTITIONS).ToNumber().Int32Value();
     if (maxPendingMessagesAcrossPartitions > 0) {
-      pulsar_producer_configuration_set_max_pending_messages_across_partitions(this->cProducerConfig.get(),
-                                                             maxPendingMessagesAcrossPartitions);
+      pulsar_producer_configuration_set_max_pending_messages_across_partitions(
+          this->cProducerConfig.get(), maxPendingMessagesAcrossPartitions);
     }
   }
 


### PR DESCRIPTION
Fix the following lint error.

```
$ npm run lint

> pulsar-client@1.7.0-rc.0 lint
> clang-format-lint src/*.cc src/*.h && eslint --ext .js .

Error: Formatting incorrect on "src/ProducerConfig.cc", proposed changes: <?xml version='1.0'?>
<replacements xml:space='preserve' incomplete_format='false'>
<replacement offset='5055' length='0'>&#10;          </replacement>
<replacement offset='5083' length='62'> </replacement>
</replacements>
```