### PR TITLE
Only send notifications to commits@ ML

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,3 +44,10 @@ github:
     merge:   false
     # disable rebase button:
     rebase:  false
+
+notifications:
+  commits:      commits@pulsar.apache.org
+  issues:       commits@pulsar.apache.org
+  pullrequests: commits@pulsar.apache.org
+  discussions:  dev@pulsar.apache.org
+  jira_options: link label


### PR DESCRIPTION
This PR modifies the Apache mailing list notifications so that commits, issues, and pull request notifications are sent to the commits@pulsar.apache.org mailing list. If you would like these notifications, please to subscribe to the commits mailing list or use the GitHub "watch" feature.

Mailing list discussion for this change: https://lists.apache.org/thread/j6y57kr4180xblh7voyrjw47blgmghwt