### PR TITLE
[refactor] Modify the README to apply the new installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,28 +26,10 @@ The Pulsar Node.js client can be used to create Pulsar producers and consumers i
 This library works only in Node.js 10.x or later because it uses the
 [node-addon-api](https://github.com/nodejs/node-addon-api) module to wrap the C++ library.
 
-## How to install
 
-> **Note**
->
-> Only available for versions after 1.8.0. For versions before 1.8.0, you need to install the C++ client first, and switch to the corresponding version branch to view the specific steps.
+## Prebuilt binaries
 
-1. You can use `npm` or `yarn` to install `pulsar-client-node`
-
-```shell
-npm install pulsar-client
-#or
-yarn add pulsar-client
-```
-
-2. Run Sample code
-
-Please refer to [examples](https://github.com/apache/pulsar-client-node/tree/master/examples).
-
-
-### Prebuilt binaries
-
-The module uses [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) to download the prebuilt binary for your platform, if it exists. 
+The module uses [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) to download the prebuilt binary for your platform, if it exists.
 These binaries are hosted on ASF dist subversion. The following targets are currently provided:
 
 Format: `napi-{platform}-{libc}-{arch}`
@@ -61,37 +43,55 @@ Format: `napi-{platform}-{libc}-{arch}`
 
 `darwin-arm64` systems are not currently supported, you can refer `How to build` to build from source.
 
+## How to install
+
+> **Note**
+>
+> These instructions are only available for versions after 1.8.0. For versions previous to 1.8.0, you need to install the C++ client first. Please switch to the corresponding version branch of this repo to read the specific instructions.
+
+### Use `npm`
+
+```shell
+npm install pulsar-client
+```
+
+### Use `yarn`
+
+```shell
+yarn add pulsar-client
+```
+
+After install, you can run the [examples](https://github.com/apache/pulsar-client-node/tree/master/examples).
+
 ## How to build
 
-To build from source, you need to install the CPP client first.
-
-1. Clone repository.
+### 1. Clone repository.
 ```shell
-$ git clone https://github.com/apache/pulsar-client-node.git
-$ cd pulsar-client-node
+git clone https://github.com/apache/pulsar-client-node.git
+cd pulsar-client-node
 ```
 
-2. Install CPP client.
+### 2. Install C++ client.
 
-Select the appropriate installation method from below depending on your operating system.
+Select the appropriate installation method from below depending on your operating system:
 
-Install c++ client on mac
+Install C++ client on macOS:
 ```shell
-$ pkg/mac/build-cpp-deps-lib.sh
-$ pkg/mac/build-cpp-lib.sh
+pkg/mac/build-cpp-deps-lib.sh
+pkg/mac/build-cpp-lib.sh
 ```
 
-Install c++ client on Linux
+Install C++ client on Linux:
 ```shell
-$ build-support/install-cpp-client.sh
+build-support/install-cpp-client.sh
 ```
 
-Install c++ client on Windows(Need install curl and 7z first)
+Install C++ client on Windows (required preinstall `curl` and `7z`):
 ```shell
-$ pkg\windows\download-cpp-client.bat
+pkg\windows\download-cpp-client.bat
 ```
 
-3. Build NAPI from source.
+### 3. Build NAPI from source
 
 ```shell
 npm install --build-from-source 
@@ -99,4 +99,4 @@ npm install --build-from-source
 
 
 ## Documentation
-* Please see https://pulsar.apache.org/docs/en/client-libraries-node for more details about the Pulsar Node.js client.  
+* Please see https://pulsar.apache.org/docs/client-libraries-node/ for more details about the Pulsar Node.js client.  

--- a/README.md
+++ b/README.md
@@ -23,155 +23,80 @@
 
 The Pulsar Node.js client can be used to create Pulsar producers and consumers in Node.js.
 
-## Requirements
-
-Pulsar Node.js client library is based on the C++ client library. Follow the instructions for
-[C++ library](https://pulsar.apache.org/docs/en/client-libraries-cpp/) for installing the binaries through
-[RPM](https://pulsar.apache.org/docs/en/client-libraries-cpp/#rpm),
-[Deb](https://pulsar.apache.org/docs/en/client-libraries-cpp/#deb) or
-[Homebrew packages](https://pulsar.apache.org/docs/en/client-libraries-cpp/#macos).
-
-(Note: you will need to install not only the pulsar-client library but also the pulsar-client-dev library)
-
-Also, this library works only in Node.js 10.x or later because it uses the
+This library works only in Node.js 10.x or later because it uses the
 [node-addon-api](https://github.com/nodejs/node-addon-api) module to wrap the C++ library.
-
-## Compatibility
-
-Compatibility between each version of the Node.js client and the C++ client is as follows:
-
-| Node.js client | C++ client      |
-|----------------|-----------------|
-| 1.0.x          | 2.3.0 or later  |
-| 1.1.x          | 2.4.0 or later  |
-| 1.2.x          | 2.5.0 or later  |
-| 1.3.x          | 2.7.0 or later  |
-| 1.4.x - 1.6.x  | 2.8.0 or later  |
-| 1.7.x          | 2.10.1 or later |
-
-If an incompatible version of the C++ client is installed, you may fail to build or run this library.
 
 ## How to install
 
-### Install on windows
+> **Note**
+>
+> Only available for versions after 1.8.0. For versions before 1.8.0, you need to install the C++ client first, and switch to the corresponding version branch to view the specific steps.
 
-1. Build the Pulsar C++ client on windows.
-
-```shell
-cmake \
- -A x64 \
- -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_TESTS=OFF \
- -DVCPKG_TRIPLET=x64-windows \
- -DCMAKE_BUILD_TYPE=Release \
- -S .
-cmake --config Release
-```
-
-
-2. Set the variable `PULSAR_CPP_DIR` with the `pulsar-client-cpp` path in a Windows command tool.
+1. You can use `npm` or `yarn` to install `pulsar-client-node`
 
 ```shell
-# for example
-set PULSAR_CPP_DIR=C:\pulsar\pulsar-client-cpp
+npm install pulsar-client
+#or
+yarn add pulsar-client
 ```
 
-3. Set the variable `OS_ARCH` in a Windows command tool, `OS_ARCH` is related to the configuration of VCPKG_TRIPLET on the command line above.(Optional)
-
-```shell
-set OS_ARCH=x64-windows
-```
-
-### Install on mac
-
-1. Install the Pulsar C++ client on mac.
-
-```shell
-brew install libpulsar
-```
-
-2. Get the installation path of libpulsar
-
-```shell
-brew info libpulsar
-```
-
-
-2. Set the variable `PULSAR_CPP_DIR` with the `pulsar-client-cpp` path in a mac command tool.
-
-```shell
-# for example
-## Intel x86_64
-export PULSAR_CPP_DIR=/usr/local/Cellar/libpulsar/2.9.1_1
-
-## Apple Silicon and Homebrew since 3.0.0
-## cf. https://brew.sh/2021/02/05/homebrew-3.0.0/
-export PULSAR_CPP_DIR=/opt/homebrew/Cellar/libpulsar/2.9.1_1
-```
-
-### Install on Linux
-
-1. Require g++ and make commands to install pulsar-client
-```
-# rpm
-$ yum install gcc-c++ make
-
-# debian
-$ apt-get install g++ make
-```
-
-2. Download rpm or debian packages.
-```
-# Set the version of Pulsar C++ client to install
-$ PULSAR_CPP_CLIENT_VERSION=2.9.1
-
-# rpm
-$ wget https://archive.apache.org/dist/pulsar/pulsar-${PULSAR_CPP_CLIENT_VERSION}/RPMS/apache-pulsar-client-${PULSAR_CPP_CLIENT_VERSION}-1.x86_64.rpm
-$ wget https://archive.apache.org/dist/pulsar/pulsar-${PULSAR_CPP_CLIENT_VERSION}/RPMS/apache-pulsar-client-devel-${PULSAR_CPP_CLIENT_VERSION}-1.x86_64.rpm
-
-# debian
-$ wget https://archive.apache.org/dist/pulsar/pulsar-${PULSAR_CPP_CLIENT_VERSION}/DEB/apache-pulsar-client.deb
-$ wget https://archive.apache.org/dist/pulsar/pulsar-${PULSAR_CPP_CLIENT_VERSION}/DEB/apache-pulsar-client-dev.deb
-```
-
-3. Install the Pulsar C++ client.
-```shell
-# rpm
-$ rpm -ivh apache-pulsar-client*.rpm
-
-# debian
-$ apt install ./apache-pulsar-client*.deb
-```
-
-
-### Install pulsar-client to your project
-
-```shell
-$ npm install pulsar-client
-```
-
-## Sample code
+2. Run Sample code
 
 Please refer to [examples](https://github.com/apache/pulsar-client-node/tree/master/examples).
 
+
+### Prebuilt binaries
+
+The module uses [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) to download the prebuilt binary for your platform, if it exists. 
+These binaries are hosted on ASF dist subversion. The following targets are currently provided:
+
+Format: `napi-{platform}-{libc}-{arch}`
+- napi-darwin-unknown-x64.tar.gz
+- napi-linux-glibc-arm64.tar.gz
+- napi-linux-glibc-x64.tar.gz
+- napi-linux-musl-arm64.tar.gz
+- napi-linux-musl-x64.tar.gz
+- napi-win32-unknown-ia32.tar.gz
+- napi-win32-unknown-x64.tar.gz
+
+`darwin-arm64` systems are not currently supported, you can refer `How to build` to build from source.
+
 ## How to build
 
-### Install dependent npm modules and build Pulsar client library:
+To build from source, you need to install the CPP client first.
 
+1. Clone repository.
 ```shell
 $ git clone https://github.com/apache/pulsar-client-node.git
 $ cd pulsar-client-node
-$ npm install
 ```
 
-> **Note**
->
-> If you build `pulsar-client-node on` windows, you need to set the variable `PULSAR_CPP_DIR` first, then install npm (run the command `npm install`) in a Windows command-line tool.
+2. Install CPP client.
 
-### Rebuild Pulsar client library:
+Select the appropriate installation method from below depending on your operating system.
+
+Install c++ client on mac
+```shell
+$ pkg/mac/build-cpp-deps-lib.sh
+$ pkg/mac/build-cpp-lib.sh
+```
+
+Install c++ client on Linux
+```shell
+$ build-support/install-cpp-client.sh
+```
+
+Install c++ client on Windows(Need install curl and 7z first)
+```shell
+$ pkg\windows\download-cpp-client.bat
+```
+
+3. Build NAPI from source.
 
 ```shell
-$ npm run build
+npm install --build-from-source 
 ```
+
 
 ## Documentation
 * Please see https://pulsar.apache.org/docs/en/client-libraries-node for more details about the Pulsar Node.js client.  

--- a/README.md
+++ b/README.md
@@ -26,23 +26,6 @@ The Pulsar Node.js client can be used to create Pulsar producers and consumers i
 This library works only in Node.js 10.x or later because it uses the
 [node-addon-api](https://github.com/nodejs/node-addon-api) module to wrap the C++ library.
 
-
-## Prebuilt binaries
-
-The module uses [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) to download the prebuilt binary for your platform, if it exists.
-These binaries are hosted on ASF dist subversion. The following targets are currently provided:
-
-Format: `napi-{platform}-{libc}-{arch}`
-- napi-darwin-unknown-x64.tar.gz
-- napi-linux-glibc-arm64.tar.gz
-- napi-linux-glibc-x64.tar.gz
-- napi-linux-musl-arm64.tar.gz
-- napi-linux-musl-x64.tar.gz
-- napi-win32-unknown-ia32.tar.gz
-- napi-win32-unknown-x64.tar.gz
-
-`darwin-arm64` systems are not currently supported, you can refer `How to build` to build from source.
-
 ## How to install
 
 > **Note**
@@ -62,6 +45,23 @@ yarn add pulsar-client
 ```
 
 After install, you can run the [examples](https://github.com/apache/pulsar-client-node/tree/master/examples).
+
+### Prebuilt binaries
+
+The module uses [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) to download the prebuilt binary for your platform, if it exists.
+These binaries are hosted on ASF dist subversion. The following targets are currently provided:
+
+Format: `napi-{platform}-{libc}-{arch}`
+- napi-darwin-unknown-x64.tar.gz
+- napi-linux-glibc-arm64.tar.gz
+- napi-linux-glibc-x64.tar.gz
+- napi-linux-musl-arm64.tar.gz
+- napi-linux-musl-x64.tar.gz
+- napi-win32-unknown-ia32.tar.gz
+- napi-win32-unknown-x64.tar.gz
+
+`darwin-arm64` systems are not currently supported, you can refer `How to build` to build from source.
+
 
 ## How to build
 

--- a/README.md
+++ b/README.md
@@ -75,18 +75,18 @@ cd pulsar-client-node
 
 Select the appropriate installation method from below depending on your operating system:
 
-Install C++ client on macOS:
+#### Install C++ client on macOS:
 ```shell
 pkg/mac/build-cpp-deps-lib.sh
 pkg/mac/build-cpp-lib.sh
 ```
 
-Install C++ client on Linux:
+#### Install C++ client on Linux:
 ```shell
 build-support/install-cpp-client.sh
 ```
 
-Install C++ client on Windows (required preinstall `curl` and `7z`):
+#### Install C++ client on Windows (required preinstall `curl` and `7z`):
 ```shell
 pkg\windows\download-cpp-client.bat
 ```

--- a/pkg/mac/common.sh
+++ b/pkg/mac/common.sh
@@ -19,7 +19,7 @@
 
 set -e -x
 
-if [ ! -n "$ARCH" ]; then
+if [ -z "$ARCH" ]; then
    export ARCH=$(uname -m)
 fi
 

--- a/pkg/mac/common.sh
+++ b/pkg/mac/common.sh
@@ -19,7 +19,10 @@
 
 set -e -x
 
-export ARCH=${ARCH:-arm64}
+if [ ! -n "$ARCH" ]; then
+   export ARCH=$(uname -m)
+fi
+
 export MACOSX_DEPLOYMENT_TARGET=11.0
 
 MAC_BUILD_DIR=`cd $(dirname $0); pwd`


### PR DESCRIPTION
### Motivation

#235 and #238 support downloading prebuilt binary when `npm install`. This simplifies installation for users. 

### Modifications
- Modify the README to apply the new install and build method.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
