### PR TITLE
Upload binaries napi to release.

### DIFF
--- a/.github/workflows/ci-build-release-napi.yml
+++ b/.github/workflows/ci-build-release-napi.yml
@@ -70,6 +70,15 @@ jobs:
           name: macos-${{matrix.nodejs}}-${{matrix.arch}}
           path: build/stage/*/*.tar.gz
 
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/stage/*/*.tar.gz
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+
   linux-napi:
     name: Build NAPI ${{matrix.image}} - Node ${{matrix.nodejs}} - ${{matrix.cpu.platform}}
     runs-on: ubuntu-22.04
@@ -121,6 +130,15 @@ jobs:
         with:
           name: ${{matrix.image}}-${{matrix.nodejs}}-${{matrix.cpu.platform}}
           path: build/stage/*/*.tar.gz
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/stage/*/*.tar.gz
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
 
   windows-napi:
     name: Build NAPI windows - Node ${{matrix.nodejs}} - ${{matrix.arch}}
@@ -184,3 +202,12 @@ jobs:
         with:
           name: windows-${{matrix.nodejs}}-${{matrix.arch}}
           path: build/stage/*/*.tar.gz
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/stage/*/*.tar.gz
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true


### PR DESCRIPTION
### Motivation

At the end of the release CI, upload the binaries to `GitHub Release`. Make it easy for users to view and download these pre-built binaries.

PS: This has nothing to do with Apache's release process

### Modifications
- Add upload-release-action on release ci end.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
