### PR TITLE
[feat][api] Expose resume and pause listeners

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,6 +98,8 @@ export class Consumer {
   negativeAcknowledgeId(messageId: MessageId): void;
   acknowledgeCumulative(message: Message): Promise<null>;
   acknowledgeCumulativeId(messageId: MessageId): Promise<null>;
+  pauseMessageListener(): Promise<null>;
+  resumeMessageListener(): Promise<null>;
   seek(messageId: MessageId): Promise<null>;
   isConnected(): boolean;
   close(): Promise<null>;

--- a/src/Consumer.h
+++ b/src/Consumer.h
@@ -48,10 +48,13 @@ class Consumer : public Napi::ObjectWrap<Consumer> {
   void NegativeAcknowledgeId(const Napi::CallbackInfo &info);
   Napi::Value AcknowledgeCumulative(const Napi::CallbackInfo &info);
   Napi::Value AcknowledgeCumulativeId(const Napi::CallbackInfo &info);
+  Napi::Value PauseMessageListener(const Napi::CallbackInfo &info);
+  Napi::Value ResumeMessageListener(const Napi::CallbackInfo &info);
   Napi::Value Seek(const Napi::CallbackInfo &info);
   Napi::Value IsConnected(const Napi::CallbackInfo &info);
   Napi::Value Close(const Napi::CallbackInfo &info);
   Napi::Value Unsubscribe(const Napi::CallbackInfo &info);
+  Napi::Value pauseResumeMessageListener(pulsar_result fn(pulsar_consumer_t *consumer));
 };
 
 #endif

--- a/src/Consumer.h
+++ b/src/Consumer.h
@@ -21,6 +21,7 @@
 #define CONSUMER_H
 
 #include <napi.h>
+#include <functional>
 #include <pulsar/c/client.h>
 #include "ConsumerConfig.h"
 #include "MessageListener.h"
@@ -54,7 +55,7 @@ class Consumer : public Napi::ObjectWrap<Consumer> {
   Napi::Value IsConnected(const Napi::CallbackInfo &info);
   Napi::Value Close(const Napi::CallbackInfo &info);
   Napi::Value Unsubscribe(const Napi::CallbackInfo &info);
-  Napi::Value pauseResumeMessageListener(pulsar_result fn(pulsar_consumer_t *consumer));
+  Napi::Value pauseResumeMessageListener(std::function<pulsar_result()>);
 };
 
 #endif

--- a/tests/end_to_end.test.js
+++ b/tests/end_to_end.test.js
@@ -189,6 +189,8 @@ const Pulsar = require('../index.js');
           const data = message.getData().toString();
           results.push(data);
           messageConsumer.acknowledge(message);
+          messageConsumer.pauseMessageListener();
+          messageConsumer.resumeMessageListener();
           if (results.length === 10) finish();
         },
       });


### PR DESCRIPTION
This should give developers the ability to limit the inflight messages with some sort of semaphore/tokenbucket

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
The idea here is that because of the async nature of node, you could endup with an infinite number of messages in flight if you use the listener feature to send a callback. Allowing the user to access the pause and resume listener, allows them to pause/resume based on the number of in-flight messages. 

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.
I just reused the [current test](https://github.com/apache/pulsar-client-node/blob/996bd91d13746e22410f22083db3637864315f07/tests/end_to_end.test.js#L192-L193) to pause and resume the listener.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
