### PR TITLE
Fix build MacOS x64 binary name error.

### DIFF
--- a/.github/workflows/ci-build-release-napi.yml
+++ b/.github/workflows/ci-build-release-napi.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - x86_64
+          - x64
 #          - arm64
         nodejs:
           - 18
@@ -41,13 +41,16 @@ jobs:
       - name: Build CPP dependencies lib
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
-          export ARCH=${{ matrix.arch }}
+          if [ "${{ matrix.arch }}" = "x64" ]; then
+            export ARCH=x86_64
+          else
+            export ARCH=${{ matrix.arch }}
+          fi
           pkg/mac/build-cpp-deps-lib.sh
 
       - name: Build CPP lib
         if: steps.cache-pulsar.outputs.cache-hit != 'true'
         run: |
-          export ARCH=${{ matrix.arch }}
           pkg/mac/build-cpp-lib.sh
 
       - name: Build Node binaries lib


### PR DESCRIPTION
### Motivation

In MacOS x64, We pre-order build binary filenames are: napi-darwin-unknown-`x86_64`.tar.gz

However, the arch obtained by [Node is](https://nodejs.org/api/os.html#osarch) x64. This way, when the user executes `npm install`, the binary file will not be found. Because it will go to request a download: napi-darwin-unknown-`x64`.tar.gz


### Modifications

- Change arch to `x64`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
