### PR TITLE
Supoort prebuild macos-arm64 arch binaries.

### DIFF
--- a/.github/workflows/ci-build-release-napi.yml
+++ b/.github/workflows/ci-build-release-napi.yml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - x86_64
-#          - arm64
+          - x64
+          - arm64
         nodejs:
           - 18
     steps:
@@ -38,16 +38,24 @@ jobs:
           path: pkg/mac/build
           key: ${{ runner.os }}-${{ matrix.arch }}-mac-${{ hashFiles('pkg/mac/build-cpp-deps-lib.sh') }}
 
+      - name: Add arch env vars
+        run: |
+          if [ "${{ matrix.arch }}" = "x64" ]; then
+            echo "ARCH=x86_64" >> $GITHUB_ENV
+          else
+            echo "ARCH=${{ matrix.target }}" >> $GITHUB_ENV
+          fi
+
       - name: Build CPP dependencies lib
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
-          export ARCH=${{ matrix.arch }}
+          export ARCH=${{ env.ARCH }}
           pkg/mac/build-cpp-deps-lib.sh
 
       - name: Build CPP lib
         if: steps.cache-pulsar.outputs.cache-hit != 'true'
         run: |
-          export ARCH=${{ matrix.arch }}
+          export ARCH=${{ env.ARCH }}
           pkg/mac/build-cpp-lib.sh
 
       - name: Build Node binaries lib
@@ -57,6 +65,7 @@ jobs:
           npx node-pre-gyp build --target_arch=${{ matrix.arch }}
 
       - name: Test loading Node binaries lib
+        if: matrix.arch == 'x64'
         run: |
           node pkg/load_test.js
 

--- a/.github/workflows/ci-build-release-napi.yml
+++ b/.github/workflows/ci-build-release-napi.yml
@@ -43,7 +43,7 @@ jobs:
           if [ "${{ matrix.arch }}" = "x64" ]; then
             echo "ARCH=x86_64" >> $GITHUB_ENV
           else
-            echo "ARCH=${{ matrix.target }}" >> $GITHUB_ENV
+            echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
           fi
 
       - name: Build CPP dependencies lib

--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -72,7 +72,7 @@ jobs:
           if [ "${{ matrix.arch }}" = "x64" ]; then
             echo "ARCH=x86_64" >> $GITHUB_ENV
           else
-            echo "ARCH=${{ matrix.target }}" >> $GITHUB_ENV
+            echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
           fi
 
       - name: Build CPP dependencies lib

--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -48,7 +48,8 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - x86_64
+          - x64
+          - arm64
         nodejs:
           - 18
     steps:
@@ -66,40 +67,40 @@ jobs:
           path: pkg/mac/build
           key: ${{ runner.os }}-${{ matrix.arch }}-mac-${{ hashFiles('pkg/mac/build-cpp-deps-lib.sh') }}
 
-      - name: Add env vars
-        shell: bash
+      - name: Add arch env vars
         run: |
-          if [ "${{ matrix.target }}" = "x86_64" ]; then
-            echo "TARGET=x64" >> $GITHUB_ENV
+          if [ "${{ matrix.arch }}" = "x64" ]; then
+            echo "ARCH=x86_64" >> $GITHUB_ENV
           else
-            echo "TARGET=${{ matrix.target }}" >> $GITHUB_ENV
+            echo "ARCH=${{ matrix.target }}" >> $GITHUB_ENV
           fi
 
       - name: Build CPP dependencies lib
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
-          export ARCH=${{ matrix.arch }}
+          export ARCH=${{ env.ARCH }}
           pkg/mac/build-cpp-deps-lib.sh
 
       - name: Build CPP lib
         if: steps.cache-pulsar.outputs.cache-hit != 'true'
         run: |
-          export ARCH=${{ matrix.arch }}
+          export ARCH=${{ env.ARCH }}
           pkg/mac/build-cpp-lib.sh
 
       - name: Build Node binaries lib
         run: |
           npm install --ignore-scripts
-          npx node-pre-gyp configure --target_arch=${{ env.TARGET }}
-          npx node-pre-gyp build --target_arch=${{ env.TARGET }}
+          npx node-pre-gyp configure --target_arch=${{ matrix.arch }}
+          npx node-pre-gyp build --target_arch=${{ matrix.arch }}
 
       - name: Test loading Node binaries lib
+        if: matrix.arch == 'x64'
         run: |
           node pkg/load_test.js
 
       - name: Package Node binaries lib
         run: |
-          npx node-pre-gyp package --target_arch=${{ env.TARGET }}
+          npx node-pre-gyp package --target_arch=${{ matrix.arch }}
 
   linux-napi:
     name: Build NAPI ${{matrix.image}} - Node ${{matrix.nodejs}} - ${{matrix.cpu.platform}}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -24,5 +24,5 @@ protobuf: 3.20.0
 zlib: 1.2.13
 zstd: 1.5.2
 snappy: 1.1.9
-openssl: 1.1.1q
+openssl: 1.1.1s
 curl: 7.85.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -24,5 +24,5 @@ protobuf: 3.20.0
 zlib: 1.2.13
 zstd: 1.5.2
 snappy: 1.1.9
-openssl: 1.1.1s
+openssl: 1.1.1q
 curl: 7.85.0

--- a/pkg/mac/build-cpp-deps-lib.sh
+++ b/pkg/mac/build-cpp-deps-lib.sh
@@ -59,6 +59,7 @@ if [ ! -f openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.done ]; then
     curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.tar.gz
     tar xfz OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.tar.gz
     pushd openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}
+        echo -e "#include <string.h>\n$(cat test/v3ext.c)" > test/v3ext.c
         if [ $ARCH = 'arm64' ]; then
           PLATFORM=darwin64-arm64-cc
         else

--- a/pkg/mac/build-cpp-deps-lib.sh
+++ b/pkg/mac/build-cpp-deps-lib.sh
@@ -59,7 +59,6 @@ if [ ! -f openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.done ]; then
     curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.tar.gz
     tar xfz OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.tar.gz
     pushd openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}
-        echo -e "#include <string.h>\n$(cat test/v3ext.c)" > test/v3ext.c
         if [ $ARCH = 'arm64' ]; then
           PLATFORM=darwin64-arm64-cc
         else
@@ -147,8 +146,8 @@ if [ ! -f snappy-${SNAPPY_VERSION}.done ]; then
     curl -O -L https://github.com/google/snappy/archive/refs/tags/${SNAPPY_VERSION}.tar.gz
     tar xfz ${SNAPPY_VERSION}.tar.gz
     pushd snappy-${SNAPPY_VERSION}
-      CXXFLAGS="-fPIC -O3 -arch ${ARCH} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
-          cmake . -DCMAKE_INSTALL_PREFIX=$PREFIX -DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF
+      CXXFLAGS="-fPIC -O3 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
+          cmake . -DCMAKE_OSX_ARCHITECTURES=${ARCH} -DCMAKE_INSTALL_PREFIX=$PREFIX -DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF
       make -j16
       make install
       touch .done
@@ -175,7 +174,8 @@ if [ ! -f curl-${CURL_VERSION}.done ]; then
               --without-brotli \
               --without-secure-transport \
               --disable-ipv6 \
-              --prefix=$PREFIX
+              --prefix=$PREFIX \
+              --host=$ARCH-apple-darwin
       make -j16 install
     popd
 

--- a/pkg/mac/build-cpp-lib.sh
+++ b/pkg/mac/build-cpp-lib.sh
@@ -29,9 +29,9 @@ cd $PULSAR_DIR
 curl -O -L "$BASE_URL"/apache-pulsar-client-cpp-${PULSAR_CPP_VERSION}.tar.gz
 tar xfz apache-pulsar-client-cpp-${PULSAR_CPP_VERSION}.tar.gz
 pushd apache-pulsar-client-cpp-${PULSAR_CPP_VERSION}
-  chmod +x ./build-support/merge_archives.sh
   rm -f CMakeCache.txt
   cmake . \
+      -DCMAKE_OSX_ARCHITECTURES=${ARCH} \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
       -DCMAKE_INSTALL_PREFIX=$PULSAR_PREFIX \
       -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
### Motivation

#235 and #238 support prebuild binaries. However, the MacOS arm64 arch is not yet supported.

### Modifications
- Supoort prebuild macos-arm64 arch binaries.
- Fixed the x64 architecture prebuild name error. #249  

### Verifying this change
You can download it [here](https://github.com/shibd/pulsar-client-node/suites/9522179570/artifacts/452316640) to validate the ARM64 prebuild binaries.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
