### PR TITLE
Upgrade OpenSSL version.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -24,5 +24,5 @@ protobuf: 3.20.0
 zlib: 1.2.13
 zstd: 1.5.2
 snappy: 1.1.9
-openssl: 1.1.1q
+openssl: 1.1.1s
 curl: 7.85.0

--- a/pkg/mac/build-cpp-deps-lib.sh
+++ b/pkg/mac/build-cpp-deps-lib.sh
@@ -59,7 +59,6 @@ if [ ! -f openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.done ]; then
     curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.tar.gz
     tar xfz OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.tar.gz
     pushd openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}
-        echo -e "#include <string.h>\n$(cat test/v3ext.c)" > test/v3ext.c
         if [ $ARCH = 'arm64' ]; then
           PLATFORM=darwin64-arm64-cc
         else


### PR DESCRIPTION
### Motivation

OpensSSL 1.1.1q has a [compilation bug](https://github.com/openssl/openssl/issues/18720), We need to solve this by adding this line manually:

```
https://github.com/apache/pulsar-client-node/blob/10ef71a0d235955d91bf763d12513eca51948df0/pkg/mac/build-cpp-deps-lib.sh#L62
```

In 1.1.1s version, this bug has [been fixed](https://github.com/openssl/openssl/issues/18720#issuecomment-1327885780).

### Modifications
- Upgrade OpenSSL version to 1.1.1s

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
