### PR TITLE
Change the require path in examples and refactor README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To use the Pulsar Node.js client in your project, run:
 npm install pulsar-client
 ```
 
-for `npm` users or
+or
 
 ```shell
 yarn add pulsar-client
@@ -80,7 +80,7 @@ const Pulsar = require('pulsar-client');
 })();
 ```
 
-You will see the following output:
+You should find the output as:
 
 ```
 hello
@@ -101,19 +101,19 @@ Since this client is a [C++ addon](https://nodejs.org/api/addons.html#c-addons) 
 
 - Install C++ client on Linux:
 
-```bash
+```shell
 build-support/install-cpp-client.sh
 ```
 
 - Install C++ client on Windows:
 
-```
+```shell
 pkg\windows\download-cpp-client.bat
 ```
 
 - Install C++ client on macOS:
 
-```
+```shell
 pkg/mac/build-cpp-deps-lib.sh
 pkg/mac/build-cpp-lib.sh
 ```
@@ -126,8 +126,13 @@ npm install
 
 To verify it has been installed successfully, you can run an example like:
 
-```bash
-$ node examples/producer
+```shell
+node examples/producer
+```
+
+You should find the output as:
+
+```
 Sent message: my-message-0
 Sent message: my-message-1
 Sent message: my-message-2

--- a/README.md
+++ b/README.md
@@ -26,77 +26,75 @@ The Pulsar Node.js client can be used to create Pulsar producers and consumers i
 This library works only in Node.js 10.x or later because it uses the
 [node-addon-api](https://github.com/nodejs/node-addon-api) module to wrap the C++ library.
 
-## How to install
+## Get Started
 
-> **Note**
->
-> These instructions are only available for versions after 1.8.0. For versions previous to 1.8.0, you need to install the C++ client first. Please switch to the corresponding version branch of this repo to read the specific instructions.
+### Install the official release
 
-### Use `npm`
+For `npm` users:
 
 ```shell
 npm install pulsar-client
 ```
 
-### Use `yarn`
+For `yarn` users:
 
 ```shell
 yarn add pulsar-client
 ```
 
-After install, you can run the [examples](https://github.com/apache/pulsar-client-node/tree/master/examples).
+## Run examples 
 
-### Prebuilt binaries
+The examples might use an API that was not included in the official npm package, so you need to install this module.
 
-The module uses [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) to download the prebuilt binary for your platform, if it exists.
-These binaries are hosted on ASF dist subversion. The following targets are currently provided:
+First, clone the repository.
 
-Format: `napi-{platform}-{libc}-{arch}`
-- napi-darwin-unknown-x64.tar.gz
-- napi-linux-glibc-arm64.tar.gz
-- napi-linux-glibc-x64.tar.gz
-- napi-linux-musl-arm64.tar.gz
-- napi-linux-musl-x64.tar.gz
-- napi-win32-unknown-ia32.tar.gz
-- napi-win32-unknown-x64.tar.gz
-
-`darwin-arm64` systems are not currently supported, you can refer `How to build` to build from source.
-
-
-## How to build
-
-### 1. Clone repository.
 ```shell
 git clone https://github.com/apache/pulsar-client-node.git
 cd pulsar-client-node
 ```
 
-### 2. Install C++ client.
+Since this client is a [C++ addon](https://nodejs.org/api/addons.html#c-addons) that depends on the [Pulsar C++ client](https://github.com/apache/pulsar-client-cpp), you need to install the C++ client first. You need to ensure there is a C++ compiler that supports C++11 installed in your system.
 
-Select the appropriate installation method from below depending on your operating system:
+- Install C++ client on Linux:
 
-#### Install C++ client on macOS:
-```shell
+```bash
+build-support/install-cpp-client.sh
+```
+
+- Install C++ client on Windows:
+
+```
+pkg\windows\download-cpp-client.bat
+```
+
+- Install C++ client on macOS:
+
+```
 pkg/mac/build-cpp-deps-lib.sh
 pkg/mac/build-cpp-lib.sh
 ```
 
-#### Install C++ client on Linux:
-```shell
-build-support/install-cpp-client.sh
-```
-
-#### Install C++ client on Windows (required preinstall `curl` and `7z`):
-```shell
-pkg\windows\download-cpp-client.bat
-```
-
-### 3. Build NAPI from source
+After the C++ client is installed, run the following command.
 
 ```shell
-npm install --build-from-source 
+npm install
 ```
 
+To verify it has been installed successfully, you can run an example like:
+
+```bash
+$ node examples/producer
+Sent message: my-message-0
+Sent message: my-message-1
+Sent message: my-message-2
+Sent message: my-message-3
+Sent message: my-message-4
+Sent message: my-message-5
+Sent message: my-message-6
+Sent message: my-message-7
+Sent message: my-message-8
+Sent message: my-message-9
+```
 
 ## Documentation
-* Please see https://pulsar.apache.org/docs/client-libraries-node/ for more details about the Pulsar Node.js client.  
+* Please see https://pulsar.apache.org/docs/client-libraries-node/ for more details about the Pulsar Node.js client.

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ You will see the following output:
 hello
 ```
 
-## More examples 
+You can see more examples in the [examples](./examples) directory. However, since these examples might use an API that was not released yet, you need to build this module. See the next section.
 
-You can see more examples in the [examples](./examples) directory. However, since these examples might use an API that was not released yet, you need to install this module.
+## How to build
 
 First, clone the repository.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ This library works only in Node.js 10.x or later because it uses the
 
 ## Getting Started
 
+> **Note**
+>
+> These instructions are only available for versions after 1.8.0. For versions previous to 1.8.0, you need to install the C++ client first. Please switch to the corresponding version branch of this repo to read the specific instructions.
+>
+> To run the examples, skip this section.
+
 To use the Pulsar Node.js client in your project, run:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -26,25 +26,63 @@ The Pulsar Node.js client can be used to create Pulsar producers and consumers i
 This library works only in Node.js 10.x or later because it uses the
 [node-addon-api](https://github.com/nodejs/node-addon-api) module to wrap the C++ library.
 
-## Get Started
+## Getting Started
 
-### Install the official release
-
-For `npm` users:
+To use the Pulsar Node.js client in your project, run:
 
 ```shell
 npm install pulsar-client
 ```
 
-For `yarn` users:
+for `npm` users or
 
 ```shell
 yarn add pulsar-client
 ```
 
-## Run examples 
+for `yarn` users.
 
-The examples might use an API that was not included in the official npm package, so you need to install this module.
+Then you can run the following simple end-to-end example:
+
+```javascript
+const Pulsar = require('pulsar-client');
+
+(async () => {
+  // Create a client
+  const client = new Pulsar.Client({
+    serviceUrl: 'pulsar://localhost:6650'
+  });
+
+  // Create a producer
+  const producer = await client.createProducer({
+    topic: 'persistent://public/default/my-topic',
+  });
+
+  // Create a consumer
+  const consumer = await client.subscribe({
+    topic: 'persistent://public/default/my-topic',
+    subscription: 'sub1'
+  });
+
+  // Send a message
+  producer.send({
+    data: Buffer.from("hello")
+  });
+
+  // Receive the message 
+  const msg = await consumer.receive();
+  console.log(msg.getData().toString());
+  consumer.acknowledge(msg);
+
+  await producer.close();
+  await consumer.close();
+  await client.close();
+})();
+```
+
+## More examples 
+
+You can see more examples in the [examples](./examples) directory. However, since these examples might use an API that was not released yet, you need to install this module.
 
 First, clone the repository.
 
@@ -74,7 +112,7 @@ pkg/mac/build-cpp-deps-lib.sh
 pkg/mac/build-cpp-lib.sh
 ```
 
-After the C++ client is installed, run the following command.
+After the C++ client is installed, run the following command to build this C++ addon.
 
 ```shell
 npm install

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ or
 yarn add pulsar-client
 ```
 
-for `yarn` users.
-
 Then you can run the following simple end-to-end example:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ const Pulsar = require('pulsar-client');
 })();
 ```
 
+You will see the following output:
+
+```
+hello
+```
+
 ## More examples 
 
 You can see more examples in the [examples](./examples) directory. However, since these examples might use an API that was not released yet, you need to install this module.

--- a/examples/consumer.js
+++ b/examples/consumer.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const Pulsar = require('pulsar-client');
+const Pulsar = require('../');
 
 (async () => {
   // Create a client

--- a/examples/consumer_listener.js
+++ b/examples/consumer_listener.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const Pulsar = require('pulsar-client');
+const Pulsar = require('../');
 
 (async () => {
   // Create a client

--- a/examples/consumer_tls_auth.js
+++ b/examples/consumer_tls_auth.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const Pulsar = require('pulsar-client');
+const Pulsar = require('../');
 
 (async () => {
   const auth = new Pulsar.AuthenticationTls({

--- a/examples/encryption-consumer.js
+++ b/examples/encryption-consumer.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const Pulsar = require('pulsar-client');
+const Pulsar = require('../');
 
 (async () => {
   // Create a client

--- a/examples/encryption-producer.js
+++ b/examples/encryption-producer.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const Pulsar = require('pulsar-client');
+const Pulsar = require('../');
 
 (async () => {
   // Create a client

--- a/examples/producer.js
+++ b/examples/producer.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const Pulsar = require('pulsar-client');
+const Pulsar = require('../');
 
 (async () => {
   // Create a client

--- a/examples/producer_tls_auth.js
+++ b/examples/producer_tls_auth.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const Pulsar = require('pulsar-client');
+const Pulsar = require('../');
 
 (async () => {
   const auth = new Pulsar.AuthenticationTls({

--- a/examples/reader.js
+++ b/examples/reader.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const Pulsar = require('pulsar-client');
+const Pulsar = require('../');
 
 (async () => {
   // Create a client

--- a/examples/reader_listener.js
+++ b/examples/reader_listener.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const Pulsar = require('pulsar-client');
+const Pulsar = require('../');
 
 (async () => {
   // Create a client


### PR DESCRIPTION
### Motivation

Currently, the scripts in `examples` directory all requires a
`pulsar-client` module installed. However, they might use some latest
APIs that were not included in official releases. We should force users
to build the client before running the examples.

### Modifications

Change `require('pulsar-client')` to `require('..')` in all `*.js`
scripts under the `examples` directory.

Simplify the README to two parts:
1. How to install the official released `pulsar-client` module. Then add a very simple end-to-end example.
2. How to build the artifacts and run the examples based on latest code.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
