### PR TITLE
Fix windows default download cpp client failed.

### DIFF
--- a/pkg/windows/download-cpp-client.bat
+++ b/pkg/windows/download-cpp-client.bat
@@ -1,8 +1,12 @@
 cd %~dp0
 set arch=%1
+if "%arch%" == "" (
+reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set arch=x86 || set arch=x64
+)
 set /P BASE_URL=<..\..\build-support\cpp-base-url.txt
 curl -O -L %BASE_URL%/%arch%-windows-static.tar.gz
 tar -xvzf %arch%-windows-static.tar.gz
-mv %arch%-windows-static pulsar-cpp
+move %arch%-windows-static pulsar-cpp
 dir
+
 


### PR DESCRIPTION
### Motivation
https://github.com/apache/pulsar-client-node/issues/256

### Modifications

- Get local `arch` when the `arch` is empty.
- Use `move` instead of `mv`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
