### PR TITLE
Bump async from 3.2.1 to 3.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4024,9 +4024,9 @@
       }
     },
     "node_modules/grunt-legacy-util/node_modules/async": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
-      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
       "dev": true
     },
     "node_modules/grunt-license-report": {
@@ -11798,9 +11798,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
-          "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg==",
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
           "dev": true
         }
       }


### PR DESCRIPTION
Fix the following vulnerability issue.

```
% npm audit               
# npm audit report

async  3.0.0 - 3.2.1
Severity: high
Prototype Pollution in async - https://github.com/advisories/GHSA-fwr7-v2mv-hh25
fix available via `npm audit fix`
node_modules/grunt-legacy-util/node_modules/async

1 high severity vulnerability

To address all issues, run:
  npm audit fix
```