### PR TITLE
[fix] Use OAuth2 on macOX arm64 failed.

### DIFF
--- a/pkg/mac/build-cpp-deps-lib.sh
+++ b/pkg/mac/build-cpp-deps-lib.sh
@@ -64,7 +64,8 @@ if [ ! -f openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.done ]; then
         else
           PLATFORM=darwin64-x86_64-cc
         fi
-        ./Configure --prefix=$PREFIX no-shared no-unit-test $PLATFORM
+        CFLAGS="-fPIC -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
+            ./Configure --prefix=$PREFIX no-shared no-unit-test $PLATFORM
         make -j8
         make install_sw
     popd
@@ -166,13 +167,18 @@ if [ ! -f curl-${CURL_VERSION}.done ]; then
     curl -O -L  https://github.com/curl/curl/releases/download/curl-${CURL_VERSION_}/curl-${CURL_VERSION}.tar.gz
     tar xfz curl-${CURL_VERSION}.tar.gz
     pushd curl-${CURL_VERSION}
+      if [ $ARCH = 'arm64' ]; then
+        SSL_CONF="--with-secure-transport"
+      else
+        SSL_CONF="--without-secure-transport --with-ssl=$PREFIX"
+      fi
       CFLAGS="-fPIC -arch ${ARCH} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
-            ./configure --with-ssl=$PREFIX \
+            ./configure \
+              ${SSL_CONF} \
               --without-nghttp2 \
               --without-libidn2 \
               --disable-ldap \
               --without-brotli \
-              --without-secure-transport \
               --disable-ipv6 \
               --prefix=$PREFIX \
               --host=$ARCH-apple-darwin


### PR DESCRIPTION
Fixes #281 

### Motivation

This issue only happened on the arm64 macOS environment and when using SSL.

This can be caused by static linking cross-compiled OpenSSL. 

I noticed that CURL could directly configure the `--with-secure-transport` parameter to use Apple's SSL/TLS implementation instead of OpenSSL: 

[Original document](https://github.com/curl/curl/blob/curl-7_85_0/docs/INSTALL.md#apple-platforms-macos-ios-tvos-watchos-and-their-simulator-counterparts): 
> On modern Apple operating systems, curl can be built to use Apple's SSL/TLS implementation, Secure Transport, instead of OpenSSL. To build with Secure Transport for SSL/TLS, use the configure option --with-secure-transport. (It is not necessary to use the option --without-openssl.)


### Modifications
- Configure the `--with-secure-transport` parameter to use Apple's SSL/TLS implementation when build arm64 macOS.

### Verifying this change

- [ ] I will add `OAuth2` related unit tests later. 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
