### PR TITLE
Fix an issue where the latest client does not work on Rocky Linux 8

### DIFF
--- a/pkg/linux/Dockerfile_linux_glibc
+++ b/pkg/linux/Dockerfile_linux_glibc
@@ -19,9 +19,7 @@
 
 ARG NODE_VERSION
 
-FROM node:${NODE_VERSION}-bullseye
-
-ARG NODE_VERSION
+FROM node:${NODE_VERSION}-buster
 
 RUN apt-get update -y && \
      apt-get install -y \

--- a/pkg/linux/download-cpp-client.sh
+++ b/pkg/linux/download-cpp-client.sh
@@ -51,7 +51,7 @@ elif [ $ID == 'alpine' ]; then
   $SUDO tar -xvf apache-pulsar-client-dev-${CPP_CLIENT_VERSION}-r0.apk
   cp -r usr/* $ROOT_DIR/pkg/linux/pulsar-cpp/
 
-elif [ $ID == '"centos"' ]; then
+elif [ $ID == '"centos"' -o $ID == '"rocky"' ]; then
   curl -L -O ${CPP_CLIENT_BASE_URL}/rpm-${PLATFORM}/${UNAME_ARCH}/apache-pulsar-client-devel-${CPP_CLIENT_VERSION}-1.${UNAME_ARCH}.rpm
   $SUDO rpm -i --prefix=$ROOT_DIR/pkg/linux/pulsar-cpp apache-pulsar-client-devel-${CPP_CLIENT_VERSION}-1.${UNAME_ARCH}.rpm --nodeps --force
 


### PR DESCRIPTION
### Motivation

The latest version of pulsar-client does not work on Rocky Linux 8.
```sh
$ head -n 2 /etc/os-release

NAME="Rocky Linux"
VERSION="8.7 (Green Obsidian)"

$ npm ls

nodejs@ /home/massakam/temp/nodejs
└── pulsar-client@1.8.0

$ node consumer.js

node:internal/modules/cjs/loader:1243
  return process.dlopen(module, path.toNamespacedPath(filename));
                 ^

Error: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by /home/massakam/temp/nodejs/node_modules/pulsar-client/lib/binding/Pulsar.node)
    at Module._extensions..node (node:internal/modules/cjs/loader:1243:18)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Module._load (node:internal/modules/cjs/loader:878:12)
    at Module.require (node:internal/modules/cjs/loader:1061:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/home/massakam/temp/nodejs/node_modules/pulsar-client/src/pulsar-binding.js:24:17)
    at Module._compile (node:internal/modules/cjs/loader:1159:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Module._load (node:internal/modules/cjs/loader:878:12) {
  code: 'ERR_DLOPEN_FAILED'
}

Node.js v18.12.1
```

The binary file `Pulsar.node` requires up to `GLIBCXX_3.4.26`, but this is not available on Rocky.
```sh
$ strings node_modules/pulsar-client/lib/binding/Pulsar.node | grep -o 'GLIBCXX_[0-9\.]\+' | sort | uniq

GLIBCXX_3.4
GLIBCXX_3.4.11
GLIBCXX_3.4.14
GLIBCXX_3.4.15
GLIBCXX_3.4.18
GLIBCXX_3.4.19
GLIBCXX_3.4.20
GLIBCXX_3.4.21
GLIBCXX_3.4.22
GLIBCXX_3.4.26
GLIBCXX_3.4.9

$ strings /lib64/libstdc++.so.6 | grep 'GLIBCXX_'

GLIBCXX_3.4
GLIBCXX_3.4.1
GLIBCXX_3.4.2
GLIBCXX_3.4.3
GLIBCXX_3.4.4
GLIBCXX_3.4.5
GLIBCXX_3.4.6
GLIBCXX_3.4.7
GLIBCXX_3.4.8
GLIBCXX_3.4.9
GLIBCXX_3.4.10
GLIBCXX_3.4.11
GLIBCXX_3.4.12
GLIBCXX_3.4.13
GLIBCXX_3.4.14
GLIBCXX_3.4.15
GLIBCXX_3.4.16
GLIBCXX_3.4.17
GLIBCXX_3.4.18
GLIBCXX_3.4.19
GLIBCXX_3.4.20
GLIBCXX_3.4.21
GLIBCXX_3.4.22
GLIBCXX_3.4.23
GLIBCXX_3.4.24
GLIBCXX_3.4.25
GLIBCXX_DEBUG_MESSAGE_LENGTH
GA+GLIBCXX_ASSERTIONS
```

This is probably because the glibc version included in the Docker image `node:18-bullseye` used to build `Pulsar.node` is too high.

### Modifications

Build binaries for Linux OSes that use glibc on `node:18-buster` (based on Debian 10.0) instead of `node:18-bullseye` (based on Debian 11.0). The binaries built on `node:18-buster` require only up to `GLIBCXX_3.4.22` and work properly on Rocky.
```sh
$ strings lib/binding/Pulsar.node | grep -o 'GLIBCXX_[0-9\.]\+' | sort | uniq

GLIBCXX_3.4
GLIBCXX_3.4.11
GLIBCXX_3.4.14
GLIBCXX_3.4.15
GLIBCXX_3.4.18
GLIBCXX_3.4.19
GLIBCXX_3.4.20
GLIBCXX_3.4.21
GLIBCXX_3.4.22
GLIBCXX_3.4.9
```

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-not-needed` 