### PR TITLE
Make it compatible with GLIBCXX_3.4.19 (CentOS 7)

### DIFF
--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -167,6 +167,14 @@ jobs:
           docker run -i -v $PWD:/pulsar-client-node build:latest \
               /pulsar-client-node/pkg/linux/build-napi-inside-docker.sh
 
+      - name: Test NAPI file in other containers
+        if: matrix.image == 'linux_glibc'
+        run: |
+          ./tests/load-test.sh node:16-buster ${{matrix.cpu.platform}}
+          ./tests/load-test.sh node:16-bullseye ${{matrix.cpu.platform}}
+          ./tests/load-test.sh node:19-buster ${{matrix.cpu.platform}}
+          ./tests/load-test.sh node:19-bullseye ${{matrix.cpu.platform}}
+
   windows-napi:
     name: Build NAPI windows - Node ${{matrix.nodejs}} - ${{matrix.arch}}
     runs-on: windows-2022

--- a/pkg/linux/Dockerfile_linux_glibc
+++ b/pkg/linux/Dockerfile_linux_glibc
@@ -17,15 +17,19 @@
 # under the License.
 #
 
-ARG NODE_VERSION
+FROM centos:7
 
-FROM node:${NODE_VERSION}-buster
+RUN yum update -y
+RUN yum install -y gcc gcc-c++ make python3
 
-RUN apt-get update -y && \
-     apt-get install -y \
-        curl \
-        g++ \
-        make \
-        python3
+WORKDIR /app
+ARG PLATFORM
+RUN SUFFIX=$(echo ${PLATFORM} | sed 's/86_//') && \
+  echo $SUFFIX && \
+  curl -O -L https://nodejs.org/download/release/v16.19.0/node-v16.19.0-linux-$SUFFIX.tar.gz && \
+  tar zxf node-v16.19.0-linux-$SUFFIX.tar.gz && \
+  mv node-v16.19.0-linux-$SUFFIX node-v16.19.0
+
+ENV PATH="/app/node-v16.19.0/bin:$PATH"
 
 CMD ["sh"]

--- a/pkg/linux/download-cpp-client.sh
+++ b/pkg/linux/download-cpp-client.sh
@@ -36,7 +36,9 @@ else
   PLATFORM=x86_64
 fi
 
+rm -rf $ROOT_DIR/pkg/linux/pulsar-cpp
 mkdir $ROOT_DIR/pkg/linux/pulsar-cpp
+rm -rf $ROOT_DIR/pkg/linux/tmp
 mkdir $ROOT_DIR/pkg/linux/tmp
 cd $ROOT_DIR/pkg/linux/tmp
 

--- a/pkg/load_test.js
+++ b/pkg/load_test.js
@@ -20,6 +20,10 @@
 const Pulsar = require('../index.js');
 
 (async () => {
+  Pulsar.Client.setLogHandler((level, file, line, message) => {
+    console.log('[%s][%s:%d] %s', Pulsar.LogLevel.toString(level), file, line, message);
+  });
+
   // Create a client
   const clientConfig = {
     serviceUrl: 'pulsar://localhost:6650',

--- a/tests/docker-load-test.sh
+++ b/tests/docker-load-test.sh
@@ -25,11 +25,11 @@ set -ex
 # Create an empty directory to test
 mkdir -p /app && cd /app
 tar zxf /pulsar-client-node/pulsar-client-node.tar.gz
-cp /pulsar-client-node/build/Release/Pulsar.node .
 
-# Import the Pulsar.node instead of the node-gyp binding
-sed -i 's/src\/pulsar-binding/Pulsar/' index.js
-find src/ -name "*.js" | xargs sed -i 's/\.\/pulsar-binding/..\/Pulsar/'
+# Use the existing Pulsar.node built in a specific container
+mkdir -p lib/binding
+cp /pulsar-client-node/build/Release/Pulsar.node lib/binding/
+npm install
 
 # Test if Pulsar.node can be loaded
 node pkg/load_test.js

--- a/tests/docker-load-test.sh
+++ b/tests/docker-load-test.sh
@@ -28,7 +28,7 @@ tar zxf /pulsar-client-node/pulsar-client-node.tar.gz
 
 # Use the existing Pulsar.node built in a specific container
 mkdir -p lib/binding
-cp /pulsar-client-node/build/Release/Pulsar.node lib/binding/
+cp /pulsar-client-node/build/Release/pulsar.node lib/binding/
 npm install
 
 # Test if Pulsar.node can be loaded

--- a/tests/docker-load-test.sh
+++ b/tests/docker-load-test.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,12 +18,18 @@
 # under the License.
 #
 
-build/
-node_modules/
-report/
-.idea
-.vscode
-*.tar.gz
-*.tgz
-pkg/linux/pulsar-cpp/
-lib/
+# NOTE: This script should only run inside a Node.js docker container.
+# See ./load-test.sh for details.
+set -ex
+
+# Create an empty directory to test
+mkdir -p /app && cd /app
+tar zxf /pulsar-client-node/pulsar-client-node.tar.gz
+cp /pulsar-client-node/build/Release/Pulsar.node .
+
+# Import the Pulsar.node instead of the node-gyp binding
+sed -i 's/src\/pulsar-binding/Pulsar/' index.js
+find src/ -name "*.js" | xargs sed -i 's/\.\/pulsar-binding/..\/Pulsar/'
+
+# Test if Pulsar.node can be loaded
+node pkg/load_test.js

--- a/tests/load-test.sh
+++ b/tests/load-test.sh
@@ -35,9 +35,9 @@ PLATFORM=$2
 ROOT_DIR=${ROOT_DIR:-$(git rev-parse --show-toplevel)}
 cd $ROOT_DIR
 
-if [[ ! -f $ROOT_DIR/pulsar-client-node.tar.gz ]]; then
-    git archive -o pulsar-client-node.tar.gz HEAD
-fi
+git archive -o pulsar-client-node.tar.gz HEAD
 
 docker run --platform $PLATFORM -v $PWD:/pulsar-client-node $IMAGE \
     /bin/bash /pulsar-client-node/tests/docker-load-test.sh
+
+rm pulsar-client-node.tar.gz

--- a/tests/load-test.sh
+++ b/tests/load-test.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,12 +18,26 @@
 # under the License.
 #
 
-build/
-node_modules/
-report/
-.idea
-.vscode
-*.tar.gz
-*.tgz
-pkg/linux/pulsar-cpp/
-lib/
+# Test if the Pulsar.node built from ../pkg/linux/build-napi-inside-docker.sh
+# can be loaded in other Linux distributions.
+
+set -e
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage $0 <node-image-name> <platform>
+
+See https://hub.docker.com/_/node for valid images"
+    exit 1
+fi
+IMAGE=$1
+PLATFORM=$2
+
+ROOT_DIR=${ROOT_DIR:-$(git rev-parse --show-toplevel)}
+cd $ROOT_DIR
+
+if [[ ! -f $ROOT_DIR/pulsar-client-node.tar.gz ]]; then
+    git archive -o pulsar-client-node.tar.gz HEAD
+fi
+
+docker run --platform $PLATFORM -v $PWD:/pulsar-client-node $IMAGE \
+    /bin/bash /pulsar-client-node/tests/docker-load-test.sh


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-node/issues/286

### Motivation

The maximum GLIBCXX version on CentOS 7 is 3.4.19. If we want to use the Pulsar Node client on CentOS 7, we have to upgrade the libstdc++.so. The reason is the libstdc++ version is too high for some systems. https://github.com/apache/pulsar-client-node/pull/285 downgrades the base image to `node:18-buster` but it still requires the `GLIBCXX_3.4.22`.

### Modifications
- Use `centos:7` as the base image to build `Pulsar.node` for glibc-based Linux distributions.
- Add `load_test.sh` to verify `Pulsar.node` can be loaded by other docker images and test Node.js 16 and 19 on Debian buster and bullseye.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
