### PR TITLE
Rename binary module_name from Pulsar to pulsar

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,7 +20,7 @@
 {
   "targets": [
     {
-      "target_name": "Pulsar",
+      "target_name": "pulsar",
       "cflags_cc": ["-std=gnu++11"],
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions", "-std=gnu++14", "-std=gnu++17"],

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "node-addon-api": "^4.3.0"
   },
   "binary": {
-    "module_name": "Pulsar",
+    "module_name": "pulsar",
     "module_path": "./lib/binding/",
     "host": "https://dist.apache.org/repos/dist/release/pulsar/pulsar-client-node/",
     "remote_path": "pulsar-client-node-{version}",


### PR DESCRIPTION

### Motivation
Currently, we can't use `the npm config argument: --{module_name}_binary_host_mirror` if we want to download binary files through a mirror.
https://github.com/mapbox/node-pre-gyp/blob/v1.0.9/README.md#download-binary-files-from-a-mirror

This is because npm will use npm_config_**p**ulsar_binary_host_mirror for the environment variable name even if running `npm install pulsar-client --Pulsar_binary_host_mirror=<mirror url>`.
Therefore, we cant' set mirror url correctly.




### Modifications

* Rename binary module_name from Pulsar to pulsar

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
