### PR TITLE
Remove unnecessary / at the end of CPP_CLIENT_BASE_URL

### DIFF
--- a/pulsar-client-cpp.txt
+++ b/pulsar-client-cpp.txt
@@ -1,2 +1,2 @@
-CPP_CLIENT_BASE_URL=https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.1.1/
+CPP_CLIENT_BASE_URL=https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.1.1
 CPP_CLIENT_VERSION=3.1.1


### PR DESCRIPTION
### Motivation

`CPP_CLIENT_BASE_URL` ends with `/`, which seems unnecessary.
```sh
$ find . -type f | xargs grep --color 'CPP_CLIENT_BASE_URL'

./pkg/linux/download-cpp-client.sh:  curl -L -O ${CPP_CLIENT_BASE_URL}/deb-${PLATFORM}/apache-pulsar-client-dev.deb
./pkg/linux/download-cpp-client.sh:  curl -L -O ${CPP_CLIENT_BASE_URL}/apk-${PLATFORM}/${UNAME_ARCH}/apache-pulsar-client-dev-${CPP_CLIENT_VERSION}-r0.apk
./pkg/linux/download-cpp-client.sh:  curl -L -O ${CPP_CLIENT_BASE_URL}/rpm-${PLATFORM}/${UNAME_ARCH}/apache-pulsar-client-devel-${CPP_CLIENT_VERSION}-1.${UNAME_ARCH}.rpm
./pkg/mac/build-cpp-lib.sh:curl -O -L "$CPP_CLIENT_BASE_URL"/apache-pulsar-client-cpp-${CPP_CLIENT_VERSION}.tar.gz
./pkg/windows/download-cpp-client.bat:curl -O -L %CPP_CLIENT_BASE_URL%/%arch%-windows-static.tar.gz
./pulsar-client-cpp.txt:CPP_CLIENT_BASE_URL=https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.1.1/
```

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
- [x] `doc-not-needed` 
- [ ] `doc` 
- [ ] `doc-complete`