### PR TITLE
Upgrade the depend on cpp version to 3.1.2.

### DIFF
--- a/pulsar-client-cpp.txt
+++ b/pulsar-client-cpp.txt
@@ -1,2 +1,2 @@
-CPP_CLIENT_BASE_URL=https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.1.1
-CPP_CLIENT_VERSION=3.1.1
+CPP_CLIENT_BASE_URL=https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.1.2
+CPP_CLIENT_VERSION=3.1.2


### PR DESCRIPTION
### Motivation

There is a TLS-related bug in Pulsar C++ client 3.1.1.

### Modifications

- Upgrade the depend on cpp version to 3.1.2.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
