### PR TITLE
[fix] MacOS  tls get certs failed.

### DIFF
--- a/pkg/mac/build-cpp-deps-lib.sh
+++ b/pkg/mac/build-cpp-deps-lib.sh
@@ -64,7 +64,7 @@ if [ ! -f openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.done ]; then
         else
           PLATFORM=darwin64-x86_64-cc
         fi
-        ./Configure --prefix=$PREFIX no-shared no-unit-test $PLATFORM
+        ./Configure --prefix=$PREFIX $SSL_DIR --openssldir=/etc/ssl no-shared no-unit-test $PLATFORM
         make -j8
         make install_sw
     popd
@@ -169,6 +169,7 @@ if [ ! -f curl-${CURL_VERSION}.done ]; then
       CFLAGS="-fPIC -arch ${ARCH} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
             ./configure --with-ssl=$PREFIX \
               --without-nghttp2 \
+              --with-ca-bundle="/etc/ssl/cert.pem" \
               --without-libidn2 \
               --disable-ldap \
               --without-brotli \

--- a/pkg/mac/build-cpp-deps-lib.sh
+++ b/pkg/mac/build-cpp-deps-lib.sh
@@ -64,10 +64,16 @@ if [ ! -f openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.done ]; then
         else
           PLATFORM=darwin64-x86_64-cc
         fi
-        ./Configure --prefix=$PREFIX $SSL_DIR --openssldir=/etc/ssl no-shared no-unit-test $PLATFORM
+        ./Configure --prefix=$PREFIX --openssldir=/etc/ssl no-shared no-unit-test $PLATFORM
         make -j8
         make install_sw
     popd
+
+    OPENSSL_DIR=$(./install/bin/openssl version -d | sed 's/\"//g')
+    if [[ $OPENSSL_DIR =~ "\/etc\/ssl" ]]; then
+        echo "The openssl dir is not set as expected: " $OPENSSL_DIR
+        exit 1
+    fi
 
     rm -rf OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.tar.gz openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}
     touch openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.done
@@ -179,6 +185,12 @@ if [ ! -f curl-${CURL_VERSION}.done ]; then
               --host=$ARCH-apple-darwin
       make -j16 install
     popd
+
+    CERT_PATH=$(./install/bin/curl -v https://example.com 2>&1 | grep CAfile)
+    if [[ $CERT_PATH =~ "\/etc\/ssl" ]]; then
+        echo "The certification path is not set as expected: " $CERT_PATH
+        exit 1
+    fi
 
     rm -rf curl-${CURL_VERSION} curl-${CURL_VERSION}.tar.gz
     touch curl-${CURL_VERSION}.done

--- a/pkg/mac/build-cpp-deps-lib.sh
+++ b/pkg/mac/build-cpp-deps-lib.sh
@@ -69,10 +69,12 @@ if [ ! -f openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.done ]; then
         make install_sw
     popd
 
-    OPENSSL_DIR=$(./install/bin/openssl version -d | sed 's/\"//g')
-    if [[ $OPENSSL_DIR =~ "\/etc\/ssl" ]]; then
-        echo "The openssl dir is not set as expected: " $OPENSSL_DIR
-        exit 1
+    if [ $ARCH = 'x64' ]; then
+      OPENSSL_DIR=$(./install/bin/openssl version -d | sed 's/\"//g')
+      if [[ $OPENSSL_DIR =~ "\/etc\/ssl" ]]; then
+          echo "The openssl dir is not set as expected: " $OPENSSL_DIR
+          exit 1
+      fi
     fi
 
     rm -rf OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.tar.gz openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}
@@ -186,10 +188,12 @@ if [ ! -f curl-${CURL_VERSION}.done ]; then
       make -j16 install
     popd
 
-    CERT_PATH=$(./install/bin/curl -v https://example.com 2>&1 | grep CAfile)
-    if [[ $CERT_PATH =~ "\/etc\/ssl" ]]; then
-        echo "The certification path is not set as expected: " $CERT_PATH
-        exit 1
+    if [ $ARCH = 'x64' ]; then
+      CERT_PATH=$(./install/bin/curl -v https://example.com 2>&1 | grep CAfile)
+      if [[ $CERT_PATH =~ "\/etc\/ssl" ]]; then
+          echo "The certification path is not set as expected: " $CERT_PATH
+          exit 1
+      fi
     fi
 
     rm -rf curl-${CURL_VERSION} curl-${CURL_VERSION}.tar.gz


### PR DESCRIPTION
### Motivation

#281 

MacOS arm64 NAPI is cross-compiled through MacOS x86's runner. The path to `certs` is not automatically recognized during compilation.

Although it is possible to set `tlsTrustCertsFilePath ` in the code to work around, this is not user-friendly.

### Modifications
- Specify the certs path when compiling `curl` and `openSSL`.


### Verifying this change
- I reproduced the issue on my local machine and used the [package](https://github.com/shibd/pulsar-client-node/suites/11135154708/artifacts/567885331) to test the pass.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
