### PR TITLE
Use the certificate provided by the node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ report/
 *.tgz
 pkg/linux/pulsar-cpp/
 lib/
+src/cert.pem

--- a/GenCertFile.js
+++ b/GenCertFile.js
@@ -19,6 +19,4 @@
 
 const Client = require('./src/Client.js');
 
-(() => {
-  Client.genCertFile();
-})();
+Client.genCertFile();

--- a/GenCertFile.js
+++ b/GenCertFile.js
@@ -17,30 +17,8 @@
  * under the License.
  */
 
-const PulsarBinding = require('./src/pulsar-binding');
-const AuthenticationTls = require('./src/AuthenticationTls.js');
-const AuthenticationAthenz = require('./src/AuthenticationAthenz.js');
-const AuthenticationToken = require('./src/AuthenticationToken.js');
-const AuthenticationOauth2 = require('./src/AuthenticationOauth2.js');
 const Client = require('./src/Client.js');
 
-const LogLevel = {
-  DEBUG: 0,
-  INFO: 1,
-  WARN: 2,
-  ERROR: 3,
-  toString: (level) => Object.keys(LogLevel).find((key) => LogLevel[key] === level),
-};
-
-const Pulsar = {
-  Client,
-  Message: PulsarBinding.Message,
-  MessageId: PulsarBinding.MessageId,
-  AuthenticationTls,
-  AuthenticationAthenz,
-  AuthenticationToken,
-  AuthenticationOauth2,
-  LogLevel,
-};
-
-module.exports = Pulsar;
+(() => {
+  Client.genCertFile();
+})();

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const AuthenticationTls = require('./src/AuthenticationTls.js');
 const AuthenticationAthenz = require('./src/AuthenticationAthenz.js');
 const AuthenticationToken = require('./src/AuthenticationToken.js');
 const AuthenticationOauth2 = require('./src/AuthenticationOauth2.js');
+const Client = require('./src/Client.js');
 
 const LogLevel = {
   DEBUG: 0,
@@ -32,7 +33,7 @@ const LogLevel = {
 };
 
 const Pulsar = {
-  Client: PulsarBinding.Client,
+  Client,
   Message: PulsarBinding.Message,
   MessageId: PulsarBinding.MessageId,
   AuthenticationTls,

--- a/index.js
+++ b/index.js
@@ -43,4 +43,8 @@ const Pulsar = {
   LogLevel,
 };
 
+(() => {
+  Client.genCertFile();
+})();
+
 module.exports = Pulsar;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "example": "examples"
   },
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build",
+    "install": "node-pre-gyp install --fallback-to-build && node index.js",
     "configure": "node-pre-gyp configure",
     "build": "npm run format && node-pre-gyp build",
     "build:debug": "npm run format && node-pre-gyp rebuild --debug",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "example": "examples"
   },
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build && node index.js",
+    "install": "node-pre-gyp install --fallback-to-build && node GenCertFile.js",
     "configure": "node-pre-gyp configure",
     "build": "npm run format && node-pre-gyp build",
     "build:debug": "npm run format && node-pre-gyp rebuild --debug",

--- a/src/Client.js
+++ b/src/Client.js
@@ -25,7 +25,7 @@ const certsFilePath = `${__dirname}/cert.pem`;
 
 class Client {
   constructor(params) {
-    if (typeof params.tlsTrustCertsFilePath === 'undefined') {
+    if (!params.tlsTrustCertsFilePath) {
       // eslint-disable-next-line no-param-reassign
       params.tlsTrustCertsFilePath = certsFilePath;
     }

--- a/src/Client.js
+++ b/src/Client.js
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+const tls = require('tls');
+const fs = require('fs');
+const os = require('os');
+const PulsarBinding = require('./pulsar-binding');
+
+const tmpCertsFilePath = `${__dirname}/cert.pem`;
+
+class Client {
+  constructor(params) {
+    if (typeof params.tlsTrustCertsFilePath === 'undefined') {
+      fs.rmSync(tmpCertsFilePath, { force: true });
+      const fd = fs.openSync(tmpCertsFilePath, 'a');
+      try {
+        tls.rootCertificates.forEach((cert) => {
+          fs.appendFileSync(fd, cert + os.EOL);
+        });
+      } finally {
+        fs.closeSync(fd);
+      }
+      // eslint-disable-next-line no-param-reassign
+      params.tlsTrustCertsFilePath = tmpCertsFilePath;
+    }
+    this.client = new PulsarBinding.Client(params);
+  }
+
+  createProducer(params) {
+    return this.client.createProducer(params);
+  }
+
+  subscribe(params) {
+    return this.client.subscribe(params);
+  }
+
+  createReader(params) {
+    return this.client.createReader(params);
+  }
+
+  close() {
+    this.client.close();
+  }
+
+  static setLogHandler(params) {
+    PulsarBinding.Client.setLogHandler(params);
+  }
+}
+
+module.exports = Client;

--- a/src/Client.js
+++ b/src/Client.js
@@ -16,27 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-const tls = require('tls');
 const fs = require('fs');
+const tls = require('tls');
 const os = require('os');
 const PulsarBinding = require('./pulsar-binding');
 
-const tmpCertsFilePath = `${__dirname}/cert.pem`;
+const certsFilePath = `${__dirname}/cert.pem`;
 
 class Client {
   constructor(params) {
     if (typeof params.tlsTrustCertsFilePath === 'undefined') {
-      fs.rmSync(tmpCertsFilePath, { force: true });
-      const fd = fs.openSync(tmpCertsFilePath, 'a');
-      try {
-        tls.rootCertificates.forEach((cert) => {
-          fs.appendFileSync(fd, cert + os.EOL);
-        });
-      } finally {
-        fs.closeSync(fd);
-      }
       // eslint-disable-next-line no-param-reassign
-      params.tlsTrustCertsFilePath = tmpCertsFilePath;
+      params.tlsTrustCertsFilePath = certsFilePath;
     }
     this.client = new PulsarBinding.Client(params);
   }
@@ -59,6 +50,18 @@ class Client {
 
   static setLogHandler(params) {
     PulsarBinding.Client.setLogHandler(params);
+  }
+
+  static genCertFile() {
+    fs.rmSync(certsFilePath, { force: true });
+    const fd = fs.openSync(certsFilePath, 'a');
+    try {
+      tls.rootCertificates.forEach((cert) => {
+        fs.appendFileSync(fd, cert + os.EOL);
+      });
+    } finally {
+      fs.closeSync(fd);
+    }
   }
 }
 


### PR DESCRIPTION
Master Issue: #281 

### Motivation

After 1.8.0, we helped users precompile CPP, resulting in users not being able to obtain system certificates when using TLS-related functions.

Current usage issues list reference: https://github.com/BewareMyPower/pulsar-tls-examples

Node.js provides [bundled Mozilla CA](https://nodejs.org/api/tls.html#tlsrootcertificates), which we can use by default.

### Modifications
- Use Node.js bundled Mozilla CA when `tlsTrustCertsFilePath` is empty.
- Since the CPP client can't set cert content direct, we first need to write the certificate content to a file and pass in the path to the CPP client.

### Verifying this change

You can clone the [repository](https://github.com/shibd/pulsar-client-tls-test) installation and verify:

```
git clone git@github.com:shibd/pulsar-client-tls-test.git
npm install
node tls-oauth2.js
node tls-token.js
```

The environment I currently verified passed is:
- Windows x64
- MacOS arm64
- Ubuntu 20.04.5

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
