### PR TITLE
[fix] Fix error when falling back to local build

### DIFF
--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -231,3 +231,68 @@ jobs:
       - name: Package Node binaries lib
         run: |
           npx node-pre-gyp package --target_arch=${{ env.TARGET }}
+
+  macos-napi-homebrew:
+    name: Build NAPI macos with CPP lib installed by Homebrew
+    runs-on: macos-latest
+    timeout-minutes: 3000
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install CPP lib
+        run: |
+          brew install libpulsar
+      - name: Build Node binaries lib
+        run: |
+          npm install --ignore-scripts
+          npx node-pre-gyp configure
+          npx node-pre-gyp build
+      - name: Test loading Node binaries lib
+        run: |
+          node pkg/load_test.js
+      - name: Package Node binaries lib
+        run: |
+          npx node-pre-gyp package
+
+  linux-napi-apt:
+    name: Build NAPI linux with CPP lib installed by APT
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3000
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install CPP lib
+        run: |
+          source pulsar-client-cpp.txt
+          UNAME_ARCH=$(uname -m)
+          if [ $UNAME_ARCH == 'aarch64' ]; then
+            PLATFORM='arm64'
+          else
+            PLATFORM='x86_64'
+          fi
+          curl -s -L -O ${CPP_CLIENT_BASE_URL}/deb-${PLATFORM}/apache-pulsar-client.deb
+          curl -s -L -O ${CPP_CLIENT_BASE_URL}/deb-${PLATFORM}/apache-pulsar-client-dev.deb
+          sudo -E apt -y install ./apache-pulsar-client.deb ./apache-pulsar-client-dev.deb
+      - name: Build Node binaries lib
+        run: |
+          npm install --ignore-scripts
+          npx node-pre-gyp configure
+          npx node-pre-gyp build
+      - name: Test loading Node binaries lib
+        run: |
+          node pkg/load_test.js
+      - name: Package Node binaries lib
+        run: |
+          npx node-pre-gyp package

--- a/binding.gyp
+++ b/binding.gyp
@@ -57,11 +57,25 @@
           "dependencies": [
             "<!@(node -p \"require('node-addon-api').gyp\")"
           ],
-          "include_dirs": [
-            "pkg/mac/build-pulsar/install/include"
-          ],
-          "libraries": [
-            "../pkg/mac/build-pulsar/install/lib/libpulsarwithdeps.a"
+          "conditions": [
+            ['"<!(test -e <(module_root_dir)/pkg/mac/build-pulsar/install && echo true || echo false)"=="true"', {
+              "include_dirs": [
+                "<(module_root_dir)/pkg/mac/build-pulsar/install/include"
+              ],
+              "libraries": [
+                "<(module_root_dir)/pkg/mac/build-pulsar/install/lib/libpulsarwithdeps.a"
+              ]
+            }, {
+              "include_dirs": [
+                "<!(brew --prefix)/include"
+              ],
+              "library_dirs": [
+                "<!(brew --prefix)/lib"
+              ],
+              "libraries": [
+                "-lpulsar"
+              ]
+            }]
           ],
         }],
         ['OS=="win"', {
@@ -75,10 +89,10 @@
             },
           },
           "include_dirs": [
-            "pkg\\windows\\pulsar-cpp\\include",
+            "<(module_root_dir)\\pkg\\windows\\pulsar-cpp\\include"
           ],
           "libraries": [
-            "..\\pkg\\windows\\pulsar-cpp\\lib\\pulsarWithDeps.lib"
+            "<(module_root_dir)\\pkg\\windows\\pulsar-cpp\\lib\\pulsarWithDeps.lib"
           ],
           "dependencies": [
             "<!(node -p \"require('node-addon-api').gyp\")"
@@ -88,11 +102,19 @@
           "dependencies": [
             "<!@(node -p \"require('node-addon-api').gyp\")"
           ],
-          "include_dirs": [
-             "pkg/linux/pulsar-cpp/include"
-          ],
-          "libraries": [
-             "../pkg/linux/pulsar-cpp/lib/libpulsarwithdeps.a"
+          "conditions": [
+            ['"<!(test -e <(module_root_dir)/pkg/linux/pulsar-cpp && echo true || echo false)"=="true"', {
+              "include_dirs": [
+                "<(module_root_dir)/pkg/linux/pulsar-cpp/include"
+              ],
+              "libraries": [
+                "<(module_root_dir)/pkg/linux/pulsar-cpp/lib/libpulsarwithdeps.a"
+              ]
+            }, {
+              "libraries": [
+                "-lpulsar"
+              ]
+            }]
           ],
         }]
       ]


### PR DESCRIPTION
### Motivation

If fetching pre-built binaries from a remote server fails, node-pre-gyp will try to fallback to building locally. However, even if the Pulsar C++ library is installed locally, this build does not succeed. This is because the C++ library must have been downloaded by a script under the `pkg` directory in this repository. Normal users other than Pulsar developers do not do this.
```sh
$ npm i pulsar-client-1.9.0-rc.0.tgz
...
npm ERR! g++: error: ../pkg/linux/pulsar-cpp/lib/libpulsarwithdeps.a: No such file or directory
```

### Modifications

Fixed `binding.gyp` to try to link to shared libraries installed by package managers such as Homebrew, RPM and APT if no C++ libraries are downloaded under the `pkg` directory.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`
