### PR TITLE
[fix] not compatible with alpine 3.15 env

### DIFF
--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -167,13 +167,19 @@ jobs:
           docker run -i -v $PWD:/pulsar-client-node build:latest \
               /pulsar-client-node/pkg/linux/build-napi-inside-docker.sh
 
-      - name: Test NAPI file in other containers
+      - name: Test NAPI file in linux_glibc containers
         if: matrix.image == 'linux_glibc'
         run: |
           ./tests/load-test.sh node:16-buster ${{matrix.cpu.platform}}
           ./tests/load-test.sh node:16-bullseye ${{matrix.cpu.platform}}
           ./tests/load-test.sh node:19-buster ${{matrix.cpu.platform}}
           ./tests/load-test.sh node:19-bullseye ${{matrix.cpu.platform}}
+
+      - name: Test NAPI file in linux_musl containers
+        if: matrix.image == 'linux_musl'
+        run: |
+          ./tests/load-test.sh node:18-alpine3.15 ${{matrix.cpu.platform}}
+          ./tests/load-test.sh node:16-alpine3.15 ${{matrix.cpu.platform}}
 
   windows-napi:
     name: Build NAPI windows - Node ${{matrix.nodejs}} - ${{matrix.arch}}

--- a/pkg/linux/Dockerfile_linux_musl
+++ b/pkg/linux/Dockerfile_linux_musl
@@ -19,7 +19,7 @@
 
 ARG NODE_VERSION
 
-FROM node:${NODE_VERSION}-alpine
+FROM node:${NODE_VERSION}-alpine3.15
 
 RUN apk add \
       bash \

--- a/tests/load-test.sh
+++ b/tests/load-test.sh
@@ -38,6 +38,6 @@ cd $ROOT_DIR
 git archive -o pulsar-client-node.tar.gz HEAD
 
 docker run --platform $PLATFORM -v $PWD:/pulsar-client-node $IMAGE \
-    /bin/bash /pulsar-client-node/tests/docker-load-test.sh
+    sh /pulsar-client-node/tests/docker-load-test.sh
 
 rm pulsar-client-node.tar.gz


### PR DESCRIPTION
Fixes #299 

### Motivation

The root cause is that pulsar-client is not compatible with `alpine3.15`. 

Currently, the binary file is compiled with the default version of alpine(3.16).

https://github.com/apache/pulsar-client-node/blob/768e76f6dc0e03f9b5aa330ffde449f67ade52a2/pkg/linux/Dockerfile_linux_musl#L22

### Modifications

- Specifies that compilation is used with `alpine3.15` version.

### Verifying this change

- Test NAPI file in alpine3.15 env.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
