### PR TITLE
[Fix] Wrap c++ exception when creating client.

### DIFF
--- a/src/Client.cc
+++ b/src/Client.cc
@@ -189,7 +189,7 @@ Client::Client(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Client>(info) 
   try {
     this->cClient = std::shared_ptr<pulsar_client_t>(
         pulsar_client_create(serviceUrl.Utf8Value().c_str(), cClientConfig.get()), pulsar_client_free);
-  } catch (const std::exception& e) {
+  } catch (const std::exception &e) {
     Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
   }
 }

--- a/src/Client.cc
+++ b/src/Client.cc
@@ -93,12 +93,11 @@ Client::Client(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Client>(info) 
   Napi::HandleScope scope(env);
   Napi::Object clientConfig = info[0].As<Napi::Object>();
 
-  if (!clientConfig.Has(CFG_SERVICE_URL) || !clientConfig.Get(CFG_SERVICE_URL).IsString()) {
-    if (clientConfig.Get(CFG_SERVICE_URL).ToString().Utf8Value().empty()) {
+  if (!clientConfig.Has(CFG_SERVICE_URL) || !clientConfig.Get(CFG_SERVICE_URL).IsString()
+      || clientConfig.Get(CFG_SERVICE_URL).ToString().Utf8Value().empty()) {
       Napi::Error::New(env, "Service URL is required and must be specified as a string")
           .ThrowAsJavaScriptException();
       return;
-    }
   }
   Napi::String serviceUrl = clientConfig.Get(CFG_SERVICE_URL).ToString();
 

--- a/src/Client.cc
+++ b/src/Client.cc
@@ -186,8 +186,12 @@ Client::Client(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Client>(info) 
     pulsar_client_configuration_set_stats_interval_in_seconds(cClientConfig.get(), statsIntervalInSeconds);
   }
 
-  this->cClient = std::shared_ptr<pulsar_client_t>(
-      pulsar_client_create(serviceUrl.Utf8Value().c_str(), cClientConfig.get()), pulsar_client_free);
+  try {
+    this->cClient = std::shared_ptr<pulsar_client_t>(
+        pulsar_client_create(serviceUrl.Utf8Value().c_str(), cClientConfig.get()), pulsar_client_free);
+  } catch (const std::exception& e) {
+    Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
+  }
 }
 
 Client::~Client() {}

--- a/src/Client.cc
+++ b/src/Client.cc
@@ -93,11 +93,11 @@ Client::Client(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Client>(info) 
   Napi::HandleScope scope(env);
   Napi::Object clientConfig = info[0].As<Napi::Object>();
 
-  if (!clientConfig.Has(CFG_SERVICE_URL) || !clientConfig.Get(CFG_SERVICE_URL).IsString()
-      || clientConfig.Get(CFG_SERVICE_URL).ToString().Utf8Value().empty()) {
-      Napi::Error::New(env, "Service URL is required and must be specified as a string")
-          .ThrowAsJavaScriptException();
-      return;
+  if (!clientConfig.Has(CFG_SERVICE_URL) || !clientConfig.Get(CFG_SERVICE_URL).IsString() ||
+      clientConfig.Get(CFG_SERVICE_URL).ToString().Utf8Value().empty()) {
+    Napi::Error::New(env, "Service URL is required and must be specified as a string")
+        .ThrowAsJavaScriptException();
+    return;
   }
   Napi::String serviceUrl = clientConfig.Get(CFG_SERVICE_URL).ToString();
 

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const Pulsar = require('../index.js');
+
+(() => {
+  describe('Client', () => {
+    describe('CreateFailedByUrlSetIncorrect', () => {
+      test('No Set Url', async () => {
+        await expect(() => new Pulsar.Client({
+          operationTimeoutSeconds: 30,
+        })).toThrow('Service URL is required and must be specified as a string');
+      });
+
+      test('Set empty url', async () => {
+        await expect(() => new Pulsar.Client({
+          serviceUrl: '',
+          operationTimeoutSeconds: 30,
+        })).toThrow('Service URL is required and must be specified as a string');
+      });
+
+      test('Set not string url', async () => {
+        await expect(() => new Pulsar.Client({
+          serviceUrl: -1,
+          operationTimeoutSeconds: 30,
+        })).toThrow('Service URL is required and must be specified as a string');
+      });
+    });
+  });
+})();

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -35,6 +35,13 @@ const Pulsar = require('../index.js');
         })).toThrow('Service URL is required and must be specified as a string');
       });
 
+      test('Set invalid url', async () => {
+        await expect(() => new Pulsar.Client({
+          serviceUrl: 'invalid://localhost:6655',
+          operationTimeoutSeconds: 30,
+        })).toThrow('Invalid scheme: invalid');
+      });
+
       test('Set not string url', async () => {
         await expect(() => new Pulsar.Client({
           serviceUrl: -1,


### PR DESCRIPTION
Fixes #303 

### Motivation

The `std::invalid_argument` exception causes the node process to exit directly, we should wrap it as a node exception that the user can catch.

### Modifications

- Wrap c++ exception when creating client.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
