### PR TITLE
[fix][perf] Modify perf_producer to run properly

### DIFF
--- a/perf/perf_producer.js
+++ b/perf/perf_producer.js
@@ -77,7 +77,7 @@ const Pulsar = require('../index.js');
   const numOfMessages = commander.messages;
   for (let i = 0; i < commander.iteration; i += 1) {
     const histogram = hdr.build({
-      bitBucketSize: 0,
+      bitBucketSize: 64,
       highestTrackableValue: 120000 * 1000,
       numberOfSignificantValueDigits: 5,
     });
@@ -104,7 +104,7 @@ const Pulsar = require('../index.js');
     console.log('Throughput produced: %f  msg/s --- %f Mbit/s --- Latency: mean: %f ms - med: %f - 95pct: %f - 99pct: %f - 99.9pct: %f - 99.99pct: %f - Max: %f',
       rate.toFixed(3),
       throuhputMbit.toFixed(3),
-      histogram.getMean(),
+      histogram.mean,
       histogram.getValueAtPercentile(50),
       histogram.getValueAtPercentile(95),
       histogram.getValueAtPercentile(99),


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation
I noticed the `perf_producer` is not working properly as follows. I want to fix it.

```
% node perf/perf_producer.js -u pulsar://localhost:6650 -t persistent://public/default/my-topic -i 1000
----------------------
size: 1024
url: pulsar://localhost:6650
topic: persistent://public/default/my-topic
iteration: 1000
messages: 1000
----------------------
/Users/equanz/src/pulsar-client-node/perf/perf_producer.js:107
      histogram.getMean(),
                ^

TypeError: histogram.getMean is not a function
    at /Users/equanz/src/pulsar-client-node/perf/perf_producer.js:107:17

Node.js v18.6.0
```

### Modifications

* Modify the `perf_producer` to address [migration procedures](https://github.com/HdrHistogram/HdrHistogramJS/tree/v2.0.1#migrating-from-v1-to-v2)

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
