### PR TITLE
[Improve] Add error handling for the message listener

### DIFF
--- a/src/Client.h
+++ b/src/Client.h
@@ -42,6 +42,9 @@ class Client : public Napi::ObjectWrap<Client> {
   static Napi::Object Init(Napi::Env env, Napi::Object exports);
   static void SetLogHandler(const Napi::CallbackInfo &info);
 
+  static void LogMessage(pulsar_logger_level_t level, const char *file, int line, const char *message,
+                         void *ctx);
+
   Client(const Napi::CallbackInfo &info);
   ~Client();
 
@@ -51,8 +54,6 @@ class Client : public Napi::ObjectWrap<Client> {
   std::shared_ptr<pulsar_client_t> cClient;
   std::shared_ptr<pulsar_client_configuration_t> cClientConfig;
 
-  static void LogMessage(pulsar_logger_level_t level, const char *file, int line, const char *message,
-                         void *ctx);
   Napi::Value CreateProducer(const Napi::CallbackInfo &info);
   Napi::Value Subscribe(const Napi::CallbackInfo &info);
   Napi::Value CreateReader(const Napi::CallbackInfo &info);

--- a/src/Consumer.h
+++ b/src/Consumer.h
@@ -36,6 +36,8 @@ class Consumer : public Napi::ObjectWrap<Consumer> {
   void SetListenerCallback(MessageListenerCallback *listener);
   void Cleanup();
   void CleanupListener();
+  std::string GetTopic();
+  std::string GetSubscriptionName();
 
  private:
   std::shared_ptr<pulsar_consumer_t> cConsumer;

--- a/src/LogUtils.h
+++ b/src/LogUtils.h
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef PULSAR_CLIENT_NODE_LOGUTILS_H
+#define PULSAR_CLIENT_NODE_LOGUTILS_H
+
+#include "Client.h"
+
+#define LOG(level, message) Client::LogMessage(pulsar_logger_level_t::level, __FILE__, __LINE__, message, 0)
+
+#define LOG_DEBUG(message) LOG(pulsar_DEBUG, message)
+#define LOG_INFO(message) LOG(pulsar_INFO, message)
+#define LOG_WARN(message) LOG(pulsar_WARN, message)
+#define LOG_ERROR(message) LOG(pulsar_ERROR, message)
+
+#endif  // PULSAR_CLIENT_NODE_LOGUTILS_H


### PR DESCRIPTION
## Motivation
Currently, there is no error handling for the message listener. If any errors are thrown from the user's listener, the program will crash.

## Modification
* Add error handling for the message listener. The client won't crash the program if there are any errors in the user function. Instead, it will log as the error.
* Add LogUtils to the internal native code.
* Add `GetTopic` and `GetSubscriptionName` for the internal native consumer.

<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

Currently, there is no error handling for the message listener. The program will crash if any errors are thrown from the user's listener.

### Modifications

* Add error handling for the message listener. The client won't crash the program if there are any errors in the user function. Instead, it will log as the error.
* Add LogUtils to the internal native code.
* Add `GetTopic` and `GetSubscriptionName` for the internal native consumer.

### Verifying this change


This change added tests.

The log will be like
```
[ERROR][../src/Consumer.cc:72] [persistent://public/default/node-test-11][sub] Message listener error in processing message: some error
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
