### PR TITLE
Upgrade unit test depends on the pulsar version to the latest(currently 3.0.0)

### DIFF
--- a/build-support/pulsar-test-service-start.sh
+++ b/build-support/pulsar-test-service-start.sh
@@ -25,7 +25,7 @@ cd $SRC_DIR
 
 build-support/pulsar-test-service-stop.sh
 
-CONTAINER_ID=$(docker run -i -p 8080:8080 -p 6650:6650 -p 8443:8443 -p 6651:6651 --rm --detach apachepulsar/pulsar:2.10.2 sleep 3600)
+CONTAINER_ID=$(docker run -i -p 8080:8080 -p 6650:6650 -p 8443:8443 -p 6651:6651 --rm --detach apachepulsar/pulsar:latest sleep 3600)
 
 echo $CONTAINER_ID >.tests-container-id.txt
 

--- a/tests/consumer.test.js
+++ b/tests/consumer.test.js
@@ -102,7 +102,7 @@ const Pulsar = require('../index.js');
           subscription: 'sub1',
           ackTimeoutMs: 10000,
           nAckRedeliverTimeoutMs: 60000,
-        })).rejects.toThrow('Failed to create consumer: BrokerMetadataError');
+        })).rejects.toThrow('Failed to create consumer: TopicNotFound');
       });
 
       test('Not Exist Namespace', async () => {
@@ -111,7 +111,7 @@ const Pulsar = require('../index.js');
           subscription: 'sub1',
           ackTimeoutMs: 10000,
           nAckRedeliverTimeoutMs: 60000,
-        })).rejects.toThrow('Failed to create consumer: BrokerMetadataError');
+        })).rejects.toThrow('Failed to create consumer: TopicNotFound');
       });
 
       test('Not Positive NAckRedeliverTimeout', async () => {

--- a/tests/producer.test.js
+++ b/tests/producer.test.js
@@ -55,7 +55,7 @@ const Pulsar = require('../index.js');
           topic: 'persistent://no-tenant/namespace/topic',
           sendTimeoutMs: 30000,
           batchingEnabled: true,
-        })).rejects.toThrow('Failed to create producer: BrokerMetadataError');
+        })).rejects.toThrow('Failed to create producer: TopicNotFound');
       });
 
       test('Not Exist Namespace', async () => {
@@ -63,7 +63,7 @@ const Pulsar = require('../index.js');
           topic: 'persistent://public/no-namespace/topic',
           sendTimeoutMs: 30000,
           batchingEnabled: true,
-        })).rejects.toThrow('Failed to create producer: BrokerMetadataError');
+        })).rejects.toThrow('Failed to create producer: TopicNotFound');
       });
 
       test('Automatic Producer Name', async () => {


### PR DESCRIPTION
### Motivation

Using the latest pulsar version to run unit tests helps us develop new features and test compatibility on time.

### Modifications

- Upgrade unit test depends on the pulsar version to the latest(currently 3.0.0).

### Verifying this change

- All unit test pass means ok.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
