### PR TITLE
[feat] End-to-end encryption support for Reader

### DIFF
--- a/examples/encryption-reader.js
+++ b/examples/encryption-reader.js
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const Pulsar = require('../');
+
+(async () => {
+  // Create a client
+  const client = new Pulsar.Client({
+    serviceUrl: 'pulsar://localhost:6650',
+    operationTimeoutSeconds: 30
+  });
+
+  // Create a reader
+  const reader = await client.createReader({
+    topic: 'persistent://public/default/my-topic',
+    startMessageId: Pulsar.MessageId.earliest(),
+    privateKeyPath: './certificate/private-key.client-rsa.pem'
+  });
+
+  // Receive messages
+  for (let i = 0; i < 10; i += 1) {
+    const msg = await reader.readNext();
+    console.log(msg.getData().toString());
+  }
+
+  await reader.close();
+  await client.close();
+})();

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,6 +119,8 @@ export interface ReaderConfig {
   subscriptionRolePrefix?: string;
   readCompacted?: boolean;
   listener?: (message: Message, reader: Reader) => void;
+  privateKeyPath?: string;
+  cryptoFailureAction?: ConsumerCryptoFailureAction;
 }
 
 export class Reader {

--- a/tstest.ts
+++ b/tstest.ts
@@ -223,6 +223,19 @@ import Pulsar = require('./index');
     },
   });
 
+  const reader4: Pulsar.Reader = await client.createReader({
+    topic: 'persistent://public/default/my-topic',
+    startMessageId: Pulsar.MessageId.earliest(),
+    privateKeyPath: '/path/to/private.key',
+  });
+
+  const reader5: Pulsar.Reader = await client.createReader({
+    topic: 'persistent://public/default/my-topic',
+    startMessageId: Pulsar.MessageId.earliest(),
+    privateKeyPath: '/path/to/private.key',
+    cryptoFailureAction: 'CONSUME',
+  });
+
   const producerName: string = producer1.getProducerName();
   const topicName1: string = producer1.getTopic();
   const producerIsConnected: boolean = producer1.isConnected();
@@ -289,6 +302,8 @@ import Pulsar = require('./index');
   await reader1.close();
   await reader2.close();
   await reader3.close();
+  await reader4.close();
+  await reader5.close();
   await client.close();
 })();
 


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #276 

### Motivation

With the underlying C library exposing the required reader config options for enabling encryption, the Node.js library can now also support end-to-end encryption when reading from a topic. 

### Modifications

- Added handling of config options required for encryption to work to the NAPI part
- Added those options to the type definition
- Added an example how to configure a Reader that reads from an encrypted topic
- Added tests

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- added integration test

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

I'm unsure what to check here since I've added an example how to create a Reader that's using encryption. But the compatibility matrix needs to be updated after this PR is merged.