### PR TITLE
[Improve] Improve log message for Reader.HasNext

### DIFF
--- a/src/Reader.cc
+++ b/src/Reader.cc
@@ -222,7 +222,9 @@ Napi::Value Reader::HasNext(const Napi::CallbackInfo &info) {
   int value = 0;
   pulsar_result result = pulsar_reader_has_message_available(this->cReader.get(), &value);
   if (result != pulsar_result_Ok) {
-    Napi::Error::New(info.Env(), "Failed to check if next message is available").ThrowAsJavaScriptException();
+    Napi::Error::New(
+        info.Env(), "Failed to check if next message is available: " + std::string(pulsar_result_str(result)))
+        .ThrowAsJavaScriptException();
     return Napi::Boolean::New(info.Env(), false);
   } else if (value == 1) {
     return Napi::Boolean::New(info.Env(), true);


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation

Currently if there is something wrong with `pulsar_reader_has_message_available`, the log will not print the actual error message. It's hard to debug without that message.

### Modifications

* Add failed result message to the log in Reader::HasNext.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
