### PR TITLE
Add partitioned topic unit test for Reader.

### DIFF
--- a/tests/http_utils.js
+++ b/tests/http_utils.js
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const http = require('http');
+
+const request = (url, { headers, data = {}, method }) => new Promise((resolve, reject) => {
+  const req = http.request(url, {
+    headers,
+    method,
+  }, (res) => {
+    let responseBody = '';
+    res.on('data', (chunk) => {
+      responseBody += chunk;
+    });
+    res.on('end', () => {
+      resolve({ responseBody, statusCode: res.statusCode });
+    });
+  });
+
+  req.on('error', (error) => {
+    reject(error);
+  });
+
+  req.write(JSON.stringify(data));
+
+  req.end();
+});
+
+module.exports = request;


### PR DESCRIPTION
Master Issue: #321 

### Motivation

CPP Client 3.2.0 support a partitioned reader. This PR add a partitioned topic unit test for Reader.

### Modifications

- Create a http_utils.js to abstract creation partitioned topic.
- Add a partitioned topic unit test for Reader.

### Verifying this change

- Reader by Partitioned Topic will cover it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
