### PR TITLE
Fix CI always failed.

### DIFF
--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -253,6 +253,7 @@ jobs:
           cache: 'npm'
       - name: Install CPP lib
         run: |
+          export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=true
           brew update
           brew install libpulsar
       - name: Build Node binaries lib


### PR DESCRIPTION
### Motivation

Currently, ci has always failed. The root cause is brew auto upgrade dependents lib version.
https://github.com/apache/pulsar-client-node/actions/runs/5242136286/jobs/9469835451?pr=331


### Modifications

- Use HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK to disable this behaviour.

### Verifying this change


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
