### PR TITLE
[fix] Fixed an issue where clients were unintentionally disconnected

### DIFF
--- a/src/Client.cc
+++ b/src/Client.cc
@@ -187,8 +187,7 @@ Client::Client(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Client>(info) 
   }
 
   try {
-    this->cClient = std::shared_ptr<pulsar_client_t>(
-        pulsar_client_create(serviceUrl.Utf8Value().c_str(), cClientConfig.get()), pulsar_client_free);
+    this->cClient = pulsar_client_create(serviceUrl.Utf8Value().c_str(), cClientConfig.get());
   } catch (const std::exception &e) {
     Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
   }
@@ -214,7 +213,7 @@ Napi::Value Client::GetPartitionsForTopic(const Napi::CallbackInfo &info) {
   auto ctx = new ExtDeferredContext(deferred);
 
   pulsar_client_get_topic_partitions_async(
-      this->cClient.get(), topic.c_str(),
+      this->cClient, topic.c_str(),
       [](pulsar_result result, pulsar_string_list_t *topicList, void *ctx) {
         auto deferredContext = static_cast<ExtDeferredContext *>(ctx);
         auto deferred = deferredContext->deferred;
@@ -275,7 +274,7 @@ Napi::Value Client::Close(const Napi::CallbackInfo &info) {
   auto ctx = new ExtDeferredContext(deferred);
 
   pulsar_client_close_async(
-      this->cClient.get(),
+      this->cClient,
       [](pulsar_result result, void *ctx) {
         auto deferredContext = static_cast<ExtDeferredContext *>(ctx);
         auto deferred = deferredContext->deferred;

--- a/src/Client.h
+++ b/src/Client.h
@@ -51,7 +51,7 @@ class Client : public Napi::ObjectWrap<Client> {
  private:
   static LogCallback *logCallback;
   static Napi::FunctionReference constructor;
-  std::shared_ptr<pulsar_client_t> cClient;
+  pulsar_client_t *cClient;
   std::shared_ptr<pulsar_client_configuration_t> cClientConfig;
 
   Napi::Value CreateProducer(const Napi::CallbackInfo &info);

--- a/src/Consumer.h
+++ b/src/Consumer.h
@@ -28,7 +28,7 @@
 class Consumer : public Napi::ObjectWrap<Consumer> {
  public:
   static void Init(Napi::Env env, Napi::Object exports);
-  static Napi::Value NewInstance(const Napi::CallbackInfo &info, std::shared_ptr<pulsar_client_t> cClient);
+  static Napi::Value NewInstance(const Napi::CallbackInfo &info, pulsar_client_t *cClient);
   static Napi::FunctionReference constructor;
   Consumer(const Napi::CallbackInfo &info);
   ~Consumer();

--- a/src/Producer.h
+++ b/src/Producer.h
@@ -27,7 +27,7 @@
 class Producer : public Napi::ObjectWrap<Producer> {
  public:
   static void Init(Napi::Env env, Napi::Object exports);
-  static Napi::Value NewInstance(const Napi::CallbackInfo &info, std::shared_ptr<pulsar_client_t> cClient);
+  static Napi::Value NewInstance(const Napi::CallbackInfo &info, pulsar_client_t *cClient);
   static Napi::FunctionReference constructor;
   Producer(const Napi::CallbackInfo &info);
   ~Producer();

--- a/src/Reader.cc
+++ b/src/Reader.cc
@@ -112,12 +112,11 @@ void Reader::SetListenerCallback(ReaderListenerCallback *listener) {
 Reader::Reader(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Reader>(info), listener(nullptr) {}
 
 struct ReaderNewInstanceContext {
-  ReaderNewInstanceContext(std::shared_ptr<ThreadSafeDeferred> deferred,
-                           std::shared_ptr<pulsar_client_t> cClient,
+  ReaderNewInstanceContext(std::shared_ptr<ThreadSafeDeferred> deferred, pulsar_client_t *cClient,
                            std::shared_ptr<ReaderConfig> readerConfig)
       : deferred(deferred), cClient(cClient), readerConfig(readerConfig){};
   std::shared_ptr<ThreadSafeDeferred> deferred;
-  std::shared_ptr<pulsar_client_t> cClient;
+  pulsar_client_t *cClient;
   std::shared_ptr<ReaderConfig> readerConfig;
 
   static void createReaderCallback(pulsar_result result, pulsar_reader_t *rawReader, void *ctx) {
@@ -143,7 +142,7 @@ struct ReaderNewInstanceContext {
   }
 };
 
-Napi::Value Reader::NewInstance(const Napi::CallbackInfo &info, std::shared_ptr<pulsar_client_t> cClient) {
+Napi::Value Reader::NewInstance(const Napi::CallbackInfo &info, pulsar_client_t *cClient) {
   auto deferred = ThreadSafeDeferred::New(info.Env());
   Napi::Object config = info[0].As<Napi::Object>();
 
@@ -162,7 +161,7 @@ Napi::Value Reader::NewInstance(const Napi::CallbackInfo &info, std::shared_ptr<
 
   auto ctx = new ReaderNewInstanceContext(deferred, cClient, readerConfig);
 
-  pulsar_client_create_reader_async(cClient.get(), topic.c_str(), readerConfig->GetCStartMessageId().get(),
+  pulsar_client_create_reader_async(cClient, topic.c_str(), readerConfig->GetCStartMessageId().get(),
                                     readerConfig->GetCReaderConfig().get(),
                                     &ReaderNewInstanceContext::createReaderCallback, ctx);
 

--- a/src/Reader.h
+++ b/src/Reader.h
@@ -27,7 +27,7 @@
 class Reader : public Napi::ObjectWrap<Reader> {
  public:
   static void Init(Napi::Env env, Napi::Object exports);
-  static Napi::Value NewInstance(const Napi::CallbackInfo &info, std::shared_ptr<pulsar_client_t> cClient);
+  static Napi::Value NewInstance(const Napi::CallbackInfo &info, pulsar_client_t *cClient);
   static Napi::FunctionReference constructor;
   Reader(const Napi::CallbackInfo &info);
   ~Reader();


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

This PR fixes an issue where client connections could be unintentionally disconnected.

### Motivation

In the code below, which is a modified version of examples/consumer_listener.js, the connection is disconnected after a few seconds. I want to fix it.

```
const Pulsar = require('../');

(async () => {
  // Create a client
  const client = new Pulsar.Client({
    serviceUrl: 'pulsar://localhost:6650',
  });

  Pulsar.Client.setLogHandler((level, file, line, message) => {
        console.log('[%s][%s:%d] %s', level, file, line, message);
    });

  // Create a consumer with listener
  const consumer = await client.subscribe({
    topic: 'persistent://public/default/my-topic',
    subscription: 'sub1',
    subscriptionType: 'Shared',
    listener: (msg, msgConsumer) => {
      console.log(msg.getData().toString());
      msgConsumer.acknowledge(msg);
    },
  });
})();
```


```
[1][Client:90] Subscribing on Topic :persistent://public/default/my-topic
[1][ClientConnection:184] [<none> -> pulsar://localhost:6650] Create ClientConnection, timeout=10000
[1][ConnectionPool:106] Created connection for pulsar://localhost:6650
[1][ClientConnection:382] [127.0.0.1:52044 -> 127.0.0.1:6650] Connected to broker
[1][HandlerBase:72] [0x600000be2f88, sub1, 0] Getting connection from pool
[1][ConsumerImpl:282] [0x600000be2f88, sub1, 0] Created consumer on broker [127.0.0.1:52044 -> 127.0.0.1:6650]
[1][ClientConnection:1236] [127.0.0.1:52044 -> 127.0.0.1:6650] Connection disconnected
```
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->

Extend cClient lifetime prevents it from being released

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
