### PR TITLE
[ci] use python-3.10

### DIFF
--- a/.github/workflows/ci-build-release-napi.yml
+++ b/.github/workflows/ci-build-release-napi.yml
@@ -41,6 +41,8 @@ jobs:
           - arm64
         nodejs:
           - 18
+        python:
+          - "3.10"
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.nodejs }}
@@ -48,7 +50,12 @@ jobs:
         with:
           node-version: ${{ matrix.nodejs }}
           cache: 'npm'
-
+          
+      - name: Use Python ${{ matrix.python }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+          
       - name: Cache Dependencies
         id: cache-dependencies
         uses: actions/cache@v3
@@ -162,6 +169,8 @@ jobs:
           - x86
         nodejs:
           - 18
+        python:
+          - "3.10"
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.nodejs }}
@@ -170,6 +179,11 @@ jobs:
           node-version: ${{ matrix.nodejs }}
           architecture: ${{ matrix.arch }}
           cache: 'npm'
+
+      - name: Use Python ${{ matrix.python }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
 
       - name: Cache CPP Client
         id: cache-dependencies

--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -30,6 +30,10 @@ jobs:
     name: Run unit tests
     runs-on: ubuntu-22.04
     timeout-minutes: 120
+    strategy:
+      matrix:
+        python:
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v3
@@ -37,6 +41,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+
+      - name: Use Python ${{ matrix.python }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+          
       - name: Run Test
         run: |
           ./tests/run-unit-tests.sh
@@ -73,6 +83,8 @@ jobs:
           - arm64
         nodejs:
           - 18
+        python:
+          - "3.10"
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.nodejs }}
@@ -80,6 +92,11 @@ jobs:
         with:
           node-version: ${{ matrix.nodejs }}
           cache: 'npm'
+          
+      - name: Use Python ${{ matrix.python }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
 
       - name: Cache Dependencies
         id: cache-dependencies
@@ -196,6 +213,8 @@ jobs:
           - x86
         nodejs:
           - 18
+        python:
+          - "3.10"
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.nodejs }}
@@ -204,6 +223,11 @@ jobs:
           node-version: ${{ matrix.nodejs }}
           architecture: ${{ matrix.arch }}
           cache: 'npm'
+
+      - name: Use Python ${{ matrix.python }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
 
       - name: Cache CPP Client
         id: cache-dependencies
@@ -246,6 +270,10 @@ jobs:
     timeout-minutes: 3000
     strategy:
       fail-fast: false
+      matrix:
+        python:
+          - "3.10"
+
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18
@@ -253,6 +281,10 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
+      - name: Use Python ${{ matrix.python }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
       - name: Install CPP lib
         run: |
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=true
@@ -276,6 +308,10 @@ jobs:
     timeout-minutes: 3000
     strategy:
       fail-fast: false
+      matrix:
+        python:
+          - "3.10"
+          
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18
@@ -283,6 +319,12 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
+
+      - name: Use Python ${{ matrix.python }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+          
       - name: Install CPP lib
         run: |
           source pulsar-client-cpp.txt


### PR DESCRIPTION
### Motivation

Currently, following jobs are failed.
```
Build NAPI macos - Node 18 - arm64
Build NAPI macos - Node 18 - x64
Build NAPI macos with CPP lib installed by Homebrew 
```

log
```
gyp info using node-gyp@9.4.0
gyp info using node@18.18.2 | darwin | x64
gyp info find Python using Python version 3.12.0 found at "/usr/local/bin/python3"
.
.
.
  File "/Users/runner/hostedtoolcache/node/18.18.2/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py", line 42, in <module>
    import gyp  # noqa: E402
    ^^^^^^^^^^
  File "/Users/runner/hostedtoolcache/node/18.18.2/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 9, in <module>
    import gyp.input
  File "/Users/runner/hostedtoolcache/node/18.18.2/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 19, in <module>
    from distutils.version import StrictVersion
ModuleNotFoundError: No module named 'distutils'
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
```

### Modifications

* specify python version to 3.10 because node-gyp-9.4.0 support v3.7, v3.8, v3.9, or v3.10.
https://github.com/nodejs/node-gyp/blob/v9.4.0/README.md


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
