### PR TITLE
Bump cpp client version to 3.4.1

### DIFF
--- a/pkg/mac/build-cpp-deps-lib.sh
+++ b/pkg/mac/build-cpp-deps-lib.sh
@@ -105,10 +105,11 @@ if [ ! -f protobuf-${PROTOBUF_VERSION}.done ]; then
     curl -O -L  https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-cpp-${PROTOBUF_VERSION}.tar.gz
     tar xfz protobuf-cpp-${PROTOBUF_VERSION}.tar.gz
     pushd protobuf-${PROTOBUF_VERSION}
-      CXXFLAGS="-fPIC -arch arm64 -arch x86_64 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
-            ./configure --prefix=$PREFIX
-      make -j16 V=1
-      make install
+     pushd cmake/
+       cmake -B build -DCMAKE_CXX_FLAGS="-fPIC -arch arm64 -arch x86_64 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
+           -DCMAKE_INSTALL_PREFIX=$PREFIX
+       cmake --build build -j16 --target install
+     popd
     popd
 
     pushd install/lib

--- a/pulsar-client-cpp.txt
+++ b/pulsar-client-cpp.txt
@@ -1,2 +1,2 @@
-CPP_CLIENT_BASE_URL=https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.2.0
-CPP_CLIENT_VERSION=3.2.0
+CPP_CLIENT_BASE_URL=https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.4.1
+CPP_CLIENT_VERSION=3.4.1

--- a/tests/consumer.test.js
+++ b/tests/consumer.test.js
@@ -137,7 +137,7 @@ const Pulsar = require('../index');
 
         await expect(consumer.close()).resolves.toEqual(null);
 
-        await expect(consumer.close()).rejects.toThrow('Failed to close consumer: AlreadyClosed');
+        await expect(consumer.close()).resolves.toEqual(null);
       });
     });
 


### PR DESCRIPTION
### Motivation

Bump cpp client version to 3.4.1

### Modifications

- Bump cpp client version to 3.4.1
- Fix related unit test.

### Verifying this change
All CI job passed.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
