### PR TITLE
Add type definition for AthenzX509Config

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -186,7 +186,7 @@ export class AuthenticationTls {
 }
 
 export class AuthenticationAthenz {
-  constructor(params: string | AthenzConfig);
+  constructor(params: string | AthenzConfig | AthenzX509Config);
 }
 
 export interface AthenzConfig {
@@ -198,7 +198,20 @@ export interface AthenzConfig {
   keyId?: string;
   principalHeader?: string;
   roleHeader?: string;
+  caCert?: string;
+  /**
+   * @deprecated
+   */
   tokenExpirationTime?: string;
+}
+
+export class AthenzX509Config {
+  providerDomain: string;
+  privateKey: string;
+  x509CertChain: string;
+  ztsUrl: string;
+  roleHeader?: string;
+  caCert?: string;
 }
 
 export class AuthenticationToken {

--- a/tstest.ts
+++ b/tstest.ts
@@ -37,6 +37,16 @@ import Pulsar = require('./index');
     principalHeader: 'Athenz-Principal-Auth',
     roleHeader: 'Athenz-Role-Auth',
     tokenExpirationTime: '3600',
+    caCert: 'file:///path/to/cacert.pem',
+  });
+
+  const authAthenz3: Pulsar.AuthenticationAthenz = new Pulsar.AuthenticationAthenz({
+    providerDomain: 'athenz.provider.domain',
+    privateKey: 'file:///path/to/private.key',
+    ztsUrl: 'https://localhost:8443',
+    roleHeader: 'Athenz-Role-Auth',
+    x509CertChain: 'file:///path/to/x509cert.pem',
+    caCert: 'file:///path/to/cacert.pem',
   });
 
   const authOauth2PrivateKey: Pulsar.AuthenticationOauth2 = new Pulsar.AuthenticationOauth2({


### PR DESCRIPTION
### Motivation
Athenz support x.509 certificate and `tokenExpirationTime`  param has been removed at  https://github.com/apache/pulsar-client-cpp/pull/274 .

### Modifications

* Add type definition for athen x.509 certificate

* Mark tokenExpirationTime as deprecated

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
