### PR TITLE
[feat] Add listenerName to client config

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,7 @@ export interface ClientConfig {
   tlsValidateHostname?: boolean;
   tlsAllowInsecureConnection?: boolean;
   statsIntervalInSeconds?: number;
+  listenerName?: string;
   log?: (level: LogLevel, file: string, line: number, message: string) => void;
 }
 

--- a/src/Client.cc
+++ b/src/Client.cc
@@ -40,6 +40,7 @@ static const std::string CFG_TLS_VALIDATE_HOSTNAME = "tlsValidateHostname";
 static const std::string CFG_TLS_ALLOW_INSECURE = "tlsAllowInsecureConnection";
 static const std::string CFG_STATS_INTERVAL = "statsIntervalInSeconds";
 static const std::string CFG_LOG = "log";
+static const std::string CFG_LISTENER_NAME = "listenerName";
 
 LogCallback *Client::logCallback = nullptr;
 
@@ -184,6 +185,11 @@ Client::Client(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Client>(info) 
   if (clientConfig.Has(CFG_STATS_INTERVAL) && clientConfig.Get(CFG_STATS_INTERVAL).IsNumber()) {
     uint32_t statsIntervalInSeconds = clientConfig.Get(CFG_STATS_INTERVAL).ToNumber().Uint32Value();
     pulsar_client_configuration_set_stats_interval_in_seconds(cClientConfig.get(), statsIntervalInSeconds);
+  }
+
+  if (clientConfig.Has(CFG_LISTENER_NAME) && clientConfig.Get(CFG_LISTENER_NAME).IsString()) {
+    Napi::String listenerName = clientConfig.Get(CFG_LISTENER_NAME).ToString();
+    pulsar_client_configuration_set_listener_name(cClientConfig.get(), listenerName.Utf8Value().c_str());
   }
 
   try {

--- a/tests/conf/standalone.conf
+++ b/tests/conf/standalone.conf
@@ -38,6 +38,13 @@ bindAddress=0.0.0.0
 # Hostname or IP address the service advertises to the outside world. If not set, the value of InetAddress.getLocalHost().getHostName() is used.
 advertisedAddress=localhost
 
+# Used to specify multiple advertised listeners for the broker.
+# The value must format as <listener_name>:pulsar://<host>:<port>,
+# multiple listeners should separate with commas.
+# Do not use this configuration with advertisedAddress and brokerServicePort.
+# The Default value is absent means use advertisedAddress and brokerServicePort.
+advertisedListeners=localhost6650:pulsar://localhost:6650,localhost6651:pulsar+ssl://localhost:6651,localhost8443:pulsar+ssl://localhost:8443
+
 # Name of the cluster to which this broker belongs to
 clusterName=standalone
 

--- a/tests/end_to_end.test.js
+++ b/tests/end_to_end.test.js
@@ -23,15 +23,16 @@ const Pulsar = require('../index');
 (() => {
   describe('End To End', () => {
     test.each([
-      ['pulsar://localhost:6650'],
-      ['pulsar+ssl://localhost:6651'],
-      ['http://localhost:8080'],
-      ['https://localhost:8443'],
-    ])('Produce/Consume to %s', async (serviceUrl) => {
+      { serviceUrl: 'pulsar://localhost:6650', listenerName: undefined },
+      { serviceUrl: 'pulsar+ssl://localhost:6651', listenerName: 'localhost6651' },
+      { serviceUrl: 'http://localhost:8080', listenerName: undefined },
+      { serviceUrl: 'https://localhost:8443', listenerName: 'localhost8443' },
+    ])('Produce/Consume to $serviceUrl', async ({ serviceUrl, listenerName }) => {
       const client = new Pulsar.Client({
         serviceUrl,
         tlsTrustCertsFilePath: `${__dirname}/certificate/server.crt`,
         operationTimeoutSeconds: 30,
+        listenerName,
       });
 
       const topic = 'persistent://public/default/produce-consume';


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #214 

<!-- or this PR is one task of an issue -->


### Motivation

This library doesn't provide a way to pass a custom listener name to a Pulsar client, which is necessary if you have multiple advertised listeners and want to hit the non-default one: https://pulsar.apache.org/docs/next/concepts-multiple-advertised-listeners/

### Modifications

<!-- Describe the modifications you've done. -->
After https://github.com/apache/pulsar-client-cpp/pull/370, `getListener` and `setListener` are now exposed in the C API, and can be used by this library as well.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- added `listenerName` to e2e tests where necessary (uses first `advertisedListener` by default)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
