### PR TITLE
feat: Use macos-arm64 github runnner to build napi package

### DIFF
--- a/.github/workflows/ci-build-release-napi.yml
+++ b/.github/workflows/ci-build-release-napi.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   macos-napi:
     name: Build NAPI macos - Node ${{matrix.nodejs}} - ${{matrix.arch}}
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 3000
 
     strategy:
@@ -43,6 +43,12 @@ jobs:
           - 18
         python:
           - "3.10"
+        include:
+          - arch: x64
+            os: macos-13
+          - arch: arm64
+            # macos-14 is used for arm64
+            os: macos-14
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.nodejs }}
@@ -56,31 +62,19 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           
-      - name: Cache Dependencies
-        id: cache-dependencies
-        uses: actions/cache@v3
-        with:
-          path: pkg/mac/build
-          key: ${{ runner.os }}-${{ matrix.arch }}-mac-${{ hashFiles('pkg/mac/build-cpp-deps-lib.sh') }}
-
-      - name: Add arch env vars
-        run: |
-          if [ "${{ matrix.arch }}" = "x64" ]; then
-            echo "ARCH=x86_64" >> $GITHUB_ENV
-          else
-            echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-          fi
-
       - name: Build Node binaries lib
         run: |
-          export ARCH=${{ env.ARCH }}
+          if [ "${{ matrix.arch }}" = "x64" ]; then
+            export ARCH=x86_64
+          else
+            export ARCH=${{ matrix.arch }}
+          fi
           pkg/mac/download-cpp-client.sh
           npm install --ignore-scripts
           npx node-pre-gyp configure --target_arch=${{ matrix.arch }}
           npx node-pre-gyp build --target_arch=${{ matrix.arch }}
 
       - name: Test loading Node binaries lib
-        if: matrix.arch == 'x64'
         run: |
           node pkg/load_test.js
 

--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -72,7 +72,7 @@ jobs:
 
   macos-napi:
     name: Build NAPI macos - Node ${{matrix.nodejs}} - ${{matrix.arch}}
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 3000
 
     strategy:
@@ -85,6 +85,12 @@ jobs:
           - 18
         python:
           - "3.10"
+        include:
+          - arch: x64
+            os: macos-13
+          - arch: arm64
+            # macos-14 is used for arm64
+            os: macos-14
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.nodejs }}
@@ -98,24 +104,19 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Add arch env vars
-        run: |
-          if [ "${{ matrix.arch }}" = "x64" ]; then
-            echo "ARCH=x86_64" >> $GITHUB_ENV
-          else
-            echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-          fi
-
       - name: Build Node binaries lib
         run: |
-          export ARCH=${{ env.ARCH }}
+          if [ "${{ matrix.arch }}" = "x64" ]; then
+            export ARCH=x86_64
+          else
+            export ARCH=${{ matrix.arch }}
+          fi
           pkg/mac/download-cpp-client.sh
           npm install --ignore-scripts
           npx node-pre-gyp configure --target_arch=${{ matrix.arch }}
           npx node-pre-gyp build --target_arch=${{ matrix.arch }}
 
       - name: Test loading Node binaries lib
-        if: matrix.arch == 'x64'
         run: |
           node pkg/load_test.js
 


### PR DESCRIPTION
### Motivation

For now, GitHub support MacOS arm64 runnner.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

- x86_64 -> macos-13
- arm64 -> macos-14

We can use the corresponding runner to compile the tests instead of cross-compiling. 

### Modifications
- Separate the compilation model of different macOS architectures.

### Verifying this change
- All ci need passed.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
