### PR TITLE
fix: Compile glibc binaries using node:buster instead of centos7

### DIFF
--- a/pkg/linux/Dockerfile_linux_glibc
+++ b/pkg/linux/Dockerfile_linux_glibc
@@ -17,19 +17,15 @@
 # under the License.
 #
 
-FROM centos:7
+ARG NODE_VERSION
 
-RUN yum update -y
-RUN yum install -y gcc gcc-c++ make python3
+FROM node:${NODE_VERSION}-buster
 
-WORKDIR /app
-ARG PLATFORM
-RUN SUFFIX=$(echo ${PLATFORM} | sed 's/86_//') && \
-  echo $SUFFIX && \
-  curl -O -L https://nodejs.org/download/release/v16.19.0/node-v16.19.0-linux-$SUFFIX.tar.gz && \
-  tar zxf node-v16.19.0-linux-$SUFFIX.tar.gz && \
-  mv node-v16.19.0-linux-$SUFFIX node-v16.19.0
-
-ENV PATH="/app/node-v16.19.0/bin:$PATH"
+RUN apt-get update -y && \
+     apt-get install -y \
+        curl \
+        g++ \
+        make \
+        python3
 
 CMD ["sh"]


### PR DESCRIPTION
### Motivation

Compile glibc binaries using node:buster instead of centos7 for two reasons:

1. Binaries compiled with centos7 may not be compatible with the node:buster (glibc) environment.
2. Centos7 has reached its [End of Life (EOL)](https://www.redhat.com/en/topics/linux/centos-linux-eol#:~:text=CentOS%20Linux%207%20will%20reach%20end%20of%20life%20(EOL)%20on,can%20help%20ease%20your%20migration)."

### Modifications

Use `node:${NODE_VERSION}-buster` to build glibc-type binaries.

### Verifying this change
1. Multi linux_glibc oss verify passed.
https://github.com/apache/pulsar-client-node/blob/13c285989743aa37e5c2b2909fadef0d343b228e/.github/workflows/ci-pr-validation.yml#L173-L179

2. Self-release build passed and verified passed.
https://github.com/shibd/pulsar-client-node/releases/tag/v1.11.0-fix.1
You can install it by: `npm install shibaodi-pulsar-client@1.11.0-fix.1`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
