### PR TITLE
[feat] Support HTTP basic for node client

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@
 
 export interface ClientConfig {
   serviceUrl: string;
-  authentication?: AuthenticationTls | AuthenticationAthenz | AuthenticationToken | AuthenticationOauth2;
+  authentication?: AuthenticationTls | AuthenticationAthenz | AuthenticationToken | AuthenticationOauth2 | AuthenticationBasic;
   operationTimeoutSeconds?: number;
   ioThreads?: number;
   messageListenerThreads?: number;
@@ -236,6 +236,13 @@ export class AuthenticationOauth2 {
     private_key?: string;
     audience?: string;
     scope?: string;
+  });
+}
+
+export class AuthenticationBasic {
+  constructor(params: {
+    username: string;
+    password: string;
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const AuthenticationTls = require('./src/AuthenticationTls');
 const AuthenticationAthenz = require('./src/AuthenticationAthenz');
 const AuthenticationToken = require('./src/AuthenticationToken');
 const AuthenticationOauth2 = require('./src/AuthenticationOauth2');
+const AuthenticationBasic = require('./src/AuthenticationBasic');
 const Client = require('./src/Client');
 
 const LogLevel = {
@@ -40,6 +41,7 @@ const Pulsar = {
   AuthenticationAthenz,
   AuthenticationToken,
   AuthenticationOauth2,
+  AuthenticationBasic,
   LogLevel,
 };
 

--- a/src/AuthenticationBasic.js
+++ b/src/AuthenticationBasic.js
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+const PulsarBinding = require('./pulsar-binding');
+
+class AuthenticationBasic {
+  constructor(params) {
+    this.binding = new PulsarBinding.Authentication('basic', params);
+  }
+}
+
+module.exports = AuthenticationBasic;

--- a/tstest.ts
+++ b/tstest.ts
@@ -73,7 +73,7 @@ import Pulsar = require('./index');
   const authBasic: Pulsar.AuthenticationBasic = new Pulsar.AuthenticationBasic({
     username: 'basic.username',
     password: 'basic.password',
-  });  
+  });
 
   const client: Pulsar.Client = new Pulsar.Client({
     serviceUrl: 'pulsar://localhost:6650',

--- a/tstest.ts
+++ b/tstest.ts
@@ -70,6 +70,11 @@ import Pulsar = require('./index');
     token: 'foobar',
   });
 
+  const authBasic: Pulsar.AuthenticationBasic = new Pulsar.AuthenticationBasic({
+    username: 'basic.username',
+    password: 'basic.password',
+  });  
+
   const client: Pulsar.Client = new Pulsar.Client({
     serviceUrl: 'pulsar://localhost:6650',
     authentication: authToken,


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

Add HTTP basic for node client

### Modifications

Adaptation of "Feature support oauth2 for node client (#190)" for HTTP basic Authn

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [x] `doc-complete`
(Docs have been already added)
