### PR TITLE
Bump cpp client version to v3.6.0

### DIFF
--- a/pulsar-client-cpp.txt
+++ b/pulsar-client-cpp.txt
@@ -1,2 +1,2 @@
-CPP_CLIENT_BASE_URL=https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.5.1
-CPP_CLIENT_VERSION=3.5.1
+CPP_CLIENT_BASE_URL=https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.6.0
+CPP_CLIENT_VERSION=3.6.0


### PR DESCRIPTION
### Motivation
Bump cpp client version to v3.6.0

### Modifications
Bump cpp client version to v3.6.0


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
