### PR TITLE
Support set log level of cpp client

### DIFF
--- a/examples/custom_logger.js
+++ b/examples/custom_logger.js
@@ -24,10 +24,10 @@ const Pulsar = require('..');
     const client = new Pulsar.Client({
         serviceUrl: 'pulsar://localhost:6650',
         operationTimeoutSeconds: 30,
-    });
-
-    Pulsar.Client.setLogHandler((level, file, line, message) => {
-        console.log('[%s][%s:%d] %s', Pulsar.LogLevel.toString(level), file, line, message);
+        log: (level, file, line, message) => {
+            console.log('[%s][%s:%d] %s', Pulsar.LogLevel.toString(level), file, line, message);
+        },
+        logLevel: Pulsar.LogLevel.DEBUG,
     });
 
     // Create a producer

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ export interface ClientConfig {
   statsIntervalInSeconds?: number;
   listenerName?: string;
   log?: (level: LogLevel, file: string, line: number, message: string) => void;
+  logLevel?: LogLevel;
 }
 
 export class Client {

--- a/src/Client.h
+++ b/src/Client.h
@@ -53,6 +53,7 @@ class Client : public Napi::ObjectWrap<Client> {
   static Napi::FunctionReference constructor;
   std::shared_ptr<pulsar_client_t> cClient;
   std::shared_ptr<pulsar_client_configuration_t> cClientConfig;
+  pulsar_logger_level_t logLevel = pulsar_logger_level_t::pulsar_INFO;
 
   Napi::Value CreateProducer(const Napi::CallbackInfo &info);
   Napi::Value Subscribe(const Napi::CallbackInfo &info);


### PR DESCRIPTION
### Motivation

Currently, when setting the log handler it uses the info level by default. 
https://github.com/apache/pulsar-client-cpp/blob/2a6916819b2a80a532f827dc96026b8fdc0b15ed/lib/c/c_ClientConfiguration.cc#L107-L109

### Modifications
- Support set log level of cpp client


### Verifying this change
- You can run examples/custom_logger.js to verify it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
