### PR TITLE
Fix release workflow and script

### DIFF
--- a/.github/workflows/ci-build-release-napi.yml
+++ b/.github/workflows/ci-build-release-napi.yml
@@ -83,7 +83,7 @@ jobs:
           npx node-pre-gyp package --target_arch=${{ matrix.arch }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos-${{matrix.nodejs}}-${{matrix.arch}}
           path: build/stage/*/*.tar.gz
@@ -135,7 +135,7 @@ jobs:
               /pulsar-client-node/pkg/linux/build-napi-inside-docker.sh
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.image}}-${{matrix.nodejs}}-${{matrix.cpu.platform}}
           path: build/stage/*/*.tar.gz
@@ -205,7 +205,7 @@ jobs:
           npx node-pre-gyp package --target_arch=${{ env.TARGET }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-${{matrix.nodejs}}-${{matrix.arch}}
           path: build/stage/*/*.tar.gz

--- a/build-support/stage-release.sh
+++ b/build-support/stage-release.sh
@@ -20,7 +20,7 @@
 
 set -e -x
 
-if [ $# -neq 2 ]; then
+if [ "$#" -ne 2 ]; then
     echo "Usage: $0 \$DEST_PATH \$WORKFLOW_ID"
     exit 1
 fi


### PR DESCRIPTION
### Modifications
1. Change upload-artifact to v4: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
2. Rewrite the download script: because original will get error, details rerfer to: https://github.com/orgs/community/discussions/88698



### Verifying this change
- verify it when released 1.13

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
