### PR TITLE
Fix segmentation fault when use token auth

### DIFF
--- a/src/Authentication.cc
+++ b/src/Authentication.cc
@@ -97,7 +97,7 @@ Napi::Object Authentication::Init(Napi::Env env, Napi::Object exports) {
 }
 
 Authentication::Authentication(const Napi::CallbackInfo &info)
-    : Napi::ObjectWrap<Authentication>(info), cAuthentication(nullptr) {
+    : Napi::ObjectWrap<Authentication>(info), cAuthentication(nullptr), tokenSupplier(nullptr) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 


### PR DESCRIPTION
### Motivation

#395 Introduce a regression on `node:20-alpine` env. if use a token to connect to pulsar, will get a segmentation fault when client closes.

```
[INFO][ClientConnection:282] [10.88.0.2:51556 -> 34.28.200.175:6651] Destroyed connection to ****
[INFO][ClientConnection:282] [10.88.0.2:51544 -> 34.28.200.175:6651] Destroyed connection to ****
Bus error (core dumped)
```

Happend here:

https://github.com/apache/pulsar-client-node/blob/c52bd1b89ca4fb76117f29215f6b0cbeb8ee8f1d/src/Authentication.cc#L181-L183


### Modifications
- We need to explicitly set `tokenSupplier` to `nullptr`, as uninitialized pointers in C++ have undefined default values.



### Verifying this change
- Verified on my local test.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
