### PR TITLE
Support set connectionTimeout param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,7 @@ export interface ClientConfig {
   listenerName?: string;
   log?: (level: LogLevel, file: string, line: number, message: string) => void;
   logLevel?: LogLevel;
+  connectionTimeoutMs?: number;
 }
 
 export class Client {

--- a/src/Client.cc
+++ b/src/Client.cc
@@ -26,6 +26,7 @@
 #include <pulsar/c/client.h>
 #include <pulsar/c/client_configuration.h>
 #include <pulsar/c/result.h>
+#include "pulsar/ClientConfiguration.h"
 
 static const std::string CFG_SERVICE_URL = "serviceUrl";
 static const std::string CFG_AUTH = "authentication";
@@ -42,8 +43,13 @@ static const std::string CFG_STATS_INTERVAL = "statsIntervalInSeconds";
 static const std::string CFG_LOG = "log";
 static const std::string CFG_LOG_LEVEL = "logLevel";
 static const std::string CFG_LISTENER_NAME = "listenerName";
+static const std::string CFG_CONNECTION_TIMEOUT = "connectionTimeoutMs";
 
 LogCallback *Client::logCallback = nullptr;
+
+struct _pulsar_client_configuration {
+  pulsar::ClientConfiguration conf;
+};
 
 void Client::SetLogHandler(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
@@ -154,6 +160,13 @@ Client::Client(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Client>(info) 
     int32_t ioThreads = clientConfig.Get(CFG_IO_THREADS).ToNumber().Int32Value();
     if (ioThreads > 0) {
       pulsar_client_configuration_set_io_threads(cClientConfig.get(), ioThreads);
+    }
+  }
+
+  if (clientConfig.Has(CFG_CONNECTION_TIMEOUT) && clientConfig.Get(CFG_CONNECTION_TIMEOUT).IsNumber()) {
+    int32_t connectionTimeoutMs = clientConfig.Get(CFG_CONNECTION_TIMEOUT).ToNumber().Int32Value();
+    if (connectionTimeoutMs > 0) {
+      cClientConfig.get()->conf.setConnectionTimeout(connectionTimeoutMs);
     }
   }
 

--- a/tests/end_to_end.test.js
+++ b/tests/end_to_end.test.js
@@ -32,6 +32,7 @@ const Pulsar = require('../index');
         serviceUrl,
         tlsTrustCertsFilePath: `${__dirname}/certificate/server.crt`,
         operationTimeoutSeconds: 30,
+        connectionTimeoutMs: 20000,
         listenerName,
       });
 


### PR DESCRIPTION
### Motivation

In the C++ client, the `connectionTimeout` parameter controls the time allowed to establish a connection, with a default value of 10 seconds

https://github.com/apache/pulsar-client-cpp/blob/4ba83e83fbb4319c0b4cda82372caf042e9ccaa6/lib/ClientConnection.cc#L184-L185

We need to expose this config on node.js client.

### Modifications
- The pulsar_client structure definition from the C++ client has been copied, allowing node.js client to set it using the C++ API instead of the C API.
- Expose `connectionTimeoutMs` configuration


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
