### PR TITLE
[fix][client] prevent garbage collection of token-supplier

### DIFF
--- a/src/Client.cc
+++ b/src/Client.cc
@@ -139,7 +139,6 @@ Client::Client(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Client>(info) 
     Napi::Object obj = clientConfig.Get(CFG_AUTH).ToObject();
     if (obj.Has(CFG_AUTH_PROP) && obj.Get(CFG_AUTH_PROP).IsObject()) {
       this->authRef_ = Napi::Persistent(obj.Get(CFG_AUTH_PROP).As<Napi::Object>());
-      this->authRef_.SuppressDestruct();
       Authentication *auth = Authentication::Unwrap(this->authRef_.Value());
       pulsar_client_configuration_set_auth(cClientConfig.get(), auth->GetCAuthentication());
     }

--- a/src/Client.cc
+++ b/src/Client.cc
@@ -138,7 +138,9 @@ Client::Client(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Client>(info) 
   if (clientConfig.Has(CFG_AUTH) && clientConfig.Get(CFG_AUTH).IsObject()) {
     Napi::Object obj = clientConfig.Get(CFG_AUTH).ToObject();
     if (obj.Has(CFG_AUTH_PROP) && obj.Get(CFG_AUTH_PROP).IsObject()) {
-      Authentication *auth = Authentication::Unwrap(obj.Get(CFG_AUTH_PROP).ToObject());
+      this->authRef_ = Napi::Persistent(obj.Get(CFG_AUTH_PROP).As<Napi::Object>());
+      this->authRef_.SuppressDestruct();
+      Authentication *auth = Authentication::Unwrap(this->authRef_.Value());
       pulsar_client_configuration_set_auth(cClientConfig.get(), auth->GetCAuthentication());
     }
   }

--- a/src/Client.h
+++ b/src/Client.h
@@ -54,6 +54,7 @@ class Client : public Napi::ObjectWrap<Client> {
   std::shared_ptr<pulsar_client_t> cClient;
   std::shared_ptr<pulsar_client_configuration_t> cClientConfig;
   pulsar_logger_level_t logLevel = pulsar_logger_level_t::pulsar_INFO;
+  Napi::ObjectReference authRef_;
 
   Napi::Value CreateProducer(const Napi::CallbackInfo &info);
   Napi::Value Subscribe(const Napi::CallbackInfo &info);


### PR DESCRIPTION
When using the new async token‐supplier API (`() => Promise<string>`) introduced in https://github.com/apache/pulsar-client-node/pull/395, the JS `Authentication` object and its backing `ThreadSafeFunction` can be garbage‐collected if no live JS references remain. After the initial token expires, Pulsar’s broker will send a new auth challenge and the native code crashes when it tries to invoke a finalized TSFN.

By persisting a reference to the authentication object in the client it prevents the V8 garbage collector from dropping the token-supplier.