### PR TITLE
Fix: Enclose variables in double quotes

### DIFF
--- a/pkg/linux/download-cpp-client.sh
+++ b/pkg/linux/download-cpp-client.sh
@@ -23,7 +23,7 @@ set -e -x
 ROOT_DIR=`cd $(dirname $0) && cd ../../ && pwd`
 source $ROOT_DIR/pulsar-client-cpp.txt
 
-if [ "$USER" != "root" ]; then
+if [ "$USER" != "root" -a "$USER" != "" ]; then
   SUDO="sudo"
 fi
 

--- a/pkg/linux/download-cpp-client.sh
+++ b/pkg/linux/download-cpp-client.sh
@@ -23,14 +23,14 @@ set -e -x
 ROOT_DIR=`cd $(dirname $0) && cd ../../ && pwd`
 source $ROOT_DIR/pulsar-client-cpp.txt
 
-if [ $USER != "root" ]; then
+if [ "$USER" != "root" ]; then
   SUDO="sudo"
 fi
 
 # Get the flavor of Linux
 export $(cat /etc/*-release | grep "^ID=")
 UNAME_ARCH=$(uname -m)
-if [ $UNAME_ARCH == 'aarch64' ]; then
+if [ "$UNAME_ARCH" == 'aarch64' ]; then
   PLATFORM=arm64
 else
   PLATFORM=x86_64
@@ -42,18 +42,18 @@ rm -rf $ROOT_DIR/pkg/linux/tmp
 mkdir $ROOT_DIR/pkg/linux/tmp
 cd $ROOT_DIR/pkg/linux/tmp
 
-if [ $ID == 'ubuntu' -o $ID == 'debian' ]; then
+if [ "$ID" == 'ubuntu' -o "$ID" == 'debian' ]; then
   curl -L -O ${CPP_CLIENT_BASE_URL}/deb-${PLATFORM}/apache-pulsar-client-dev.deb
   $SUDO ar x apache-pulsar-client-dev.deb
   $SUDO tar -xvf data.tar.xz
   cp -r usr/* $ROOT_DIR/pkg/linux/pulsar-cpp/
 
-elif [ $ID == 'alpine' ]; then
+elif [ "$ID" == 'alpine' ]; then
   curl -L -O ${CPP_CLIENT_BASE_URL}/apk-${PLATFORM}/${UNAME_ARCH}/apache-pulsar-client-dev-${CPP_CLIENT_VERSION}-r0.apk
   $SUDO tar -xvf apache-pulsar-client-dev-${CPP_CLIENT_VERSION}-r0.apk
   cp -r usr/* $ROOT_DIR/pkg/linux/pulsar-cpp/
 
-elif [ $ID == '"centos"' -o $ID == '"rocky"' ]; then
+elif [ "$ID" == '"centos"' -o "$ID" == '"rocky"' ]; then
   curl -L -O ${CPP_CLIENT_BASE_URL}/rpm-${PLATFORM}/${UNAME_ARCH}/apache-pulsar-client-devel-${CPP_CLIENT_VERSION}-1.${UNAME_ARCH}.rpm
   $SUDO rpm -i --prefix=$ROOT_DIR/pkg/linux/pulsar-cpp apache-pulsar-client-devel-${CPP_CLIENT_VERSION}-1.${UNAME_ARCH}.rpm --nodeps --force
 


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

* Variables in the script should be enclosed in double quotes.
```
./download-cpp-client.sh: line 26: [: !=: unary operator expected
```

### Modifications

* Enclose variables in double quotes in download-cpp-client.sh

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
