### PR TITLE
[fix][client] handle subscriptionRolePrefix properly

### DIFF
--- a/src/ReaderConfig.cc
+++ b/src/ReaderConfig.cc
@@ -72,7 +72,8 @@ ReaderConfig::ReaderConfig(const Napi::Object &readerConfig, pulsar_reader_liste
     std::string subscriptionRolePrefix =
         readerConfig.Get(CFG_SUBSCRIPTION_ROLE_PREFIX).ToString().Utf8Value();
     if (!subscriptionRolePrefix.empty())
-      pulsar_reader_configuration_set_reader_name(this->cReaderConfig.get(), subscriptionRolePrefix.c_str());
+      pulsar_reader_configuration_set_subscription_role_prefix(this->cReaderConfig.get(),
+                                                               subscriptionRolePrefix.c_str());
   }
 
   if (readerConfig.Has(CFG_READ_COMPACTED) && readerConfig.Get(CFG_READ_COMPACTED).IsBoolean()) {


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #415 

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

At my current employer, we have a centrally-managed Pulsar cluster that requires use of a pre-assigned `subscriptionRolePrefix` for your client when creating a reader.

As per docs, you should be able to do this with:

```
client.createReader({
  topic,
  startMessageId: Pulsar.MessageId.earliest(),
  subscriptionRolePrefix: subscriptionPrefix,
});
```

However, this bug prevents that from working correctly.

### Modifications

Small change in `ReaderConfig.cc` to call the correct `PULSAR_PUBLIC` function.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.  That said: I did test that, by using my patched client, I can create a reader in our internal setup described above.  (Without the patch, it fails.)

(Due to NDA, I can't describe that setup in more detail, sadly.)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

Docs are not needed: this fixes a feature that is already documented, but which did not previously work as intended.
