### PR TITLE
Support consumer key-shared policy

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -103,6 +103,7 @@ export interface ConsumerConfig {
   regexSubscriptionMode?: RegexSubscriptionMode;
   deadLetterPolicy?: DeadLetterPolicy;
   batchReceivePolicy?: ConsumerBatchReceivePolicy;
+  keySharedPolicy?: KeySharedPolicy;
 }
 
 export class Consumer {
@@ -192,6 +193,18 @@ export interface ConsumerBatchReceivePolicy {
   maxNumMessages?: number;
   maxNumBytes?: number;
   timeoutMs?: number;
+}
+
+export interface ConsumerKeyShareStickyRange {
+  start: number;
+  end: number;
+}
+export type ConsumerKeyShareStickyRanges = ConsumerKeyShareStickyRange[];
+
+export interface KeySharedPolicy {
+  keyShareMode?: ConsumerKeyShareMode;
+  allowOutOfOrderDelivery?: boolean;
+  stickyRanges?: ConsumerKeyShareStickyRanges;
 }
 
 export class AuthenticationTls {
@@ -295,6 +308,10 @@ export type ConsumerCryptoFailureAction =
   'FAIL' |
   'DISCARD' |
   'CONSUME';
+
+export type ConsumerKeyShareMode =
+    'AutoSplit' |
+    'Sticky';
 
 export type RegexSubscriptionMode =
   'PersistentOnly' |


### PR DESCRIPTION
### Motivation
https://github.com/apache/pulsar-client-node/issues/408


### Modifications
- Support consumer key-shared policy

### Verifying this change
- Add testStickyConsumer to cover this.
- Other case covered by the CPP client.

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
