### PR TITLE
Ignore src/cert.pem

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+.idea
 .github
 build-support
 docs
@@ -32,6 +33,9 @@ tsconfig.json
 tslint.json
 tstest.ts
 typedoc.json
+
+# pem
+src/cert.pem
 
 # license
 license-checker-config.json


### PR DESCRIPTION
### Motivation
The [1.14.0-rc.1](https://www.npmjs.com/package/pulsar-client/v/1.14.0-rc.1) has 427KB, it more than [v1.13.2](https://www.npmjs.com/package/pulsar-client/v/1.13.2)


### Modifications
- Ignore src/cert.pem
- Ignore .idea

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
