### PR TITLE
Support separate TLS handshake certificate/private key in Client

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,8 @@ export interface ClientConfig {
   concurrentLookupRequest?: number;
   useTls?: boolean;
   tlsTrustCertsFilePath?: string;
+  tlsCertificateFilePath?: string;
+  tlsPrivateKeyFilePath?: string;
   tlsValidateHostname?: boolean;
   tlsAllowInsecureConnection?: boolean;
   statsIntervalInSeconds?: number;

--- a/src/Client.cc
+++ b/src/Client.cc
@@ -39,6 +39,8 @@ static const std::string CFG_USE_TLS = "useTls";
 static const std::string CFG_TLS_TRUST_CERT = "tlsTrustCertsFilePath";
 static const std::string CFG_TLS_VALIDATE_HOSTNAME = "tlsValidateHostname";
 static const std::string CFG_TLS_ALLOW_INSECURE = "tlsAllowInsecureConnection";
+static const std::string CFG_TLS_CERT_FILE = "tlsCertificateFilePath";
+static const std::string CFG_TLS_PRIVATE_KEY_FILE = "tlsPrivateKeyFilePath";
 static const std::string CFG_STATS_INTERVAL = "statsIntervalInSeconds";
 static const std::string CFG_LOG = "log";
 static const std::string CFG_LOG_LEVEL = "logLevel";
@@ -194,6 +196,18 @@ Client::Client(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Client>(info) 
     Napi::String tlsTrustCertsFilePath = clientConfig.Get(CFG_TLS_TRUST_CERT).ToString();
     pulsar_client_configuration_set_tls_trust_certs_file_path(cClientConfig.get(),
                                                               tlsTrustCertsFilePath.Utf8Value().c_str());
+  }
+
+  if (clientConfig.Has(CFG_TLS_CERT_FILE) && clientConfig.Get(CFG_TLS_CERT_FILE).IsString()) {
+    Napi::String tlsCertFilePath = clientConfig.Get(CFG_TLS_CERT_FILE).ToString();
+    pulsar_client_configuration_set_tls_certificate_file_path(cClientConfig.get(),
+                                                              tlsCertFilePath.Utf8Value().c_str());
+  }
+
+  if (clientConfig.Has(CFG_TLS_PRIVATE_KEY_FILE) && clientConfig.Get(CFG_TLS_PRIVATE_KEY_FILE).IsString()) {
+    Napi::String tlsPrivateKeyFilePath = clientConfig.Get(CFG_TLS_PRIVATE_KEY_FILE).ToString();
+    pulsar_client_configuration_set_tls_private_key_file_path(cClientConfig.get(),
+                                                              tlsPrivateKeyFilePath.Utf8Value().c_str());
   }
 
   if (clientConfig.Has(CFG_TLS_VALIDATE_HOSTNAME) &&

--- a/tests/conf/standalone.conf
+++ b/tests/conf/standalone.conf
@@ -115,6 +115,9 @@ tlsKeyFilePath=/pulsar/test-conf/server.key
 # fails, then the certs are untrusted and the connections are dropped.
 tlsTrustCertsFilePath=/pulsar/test-conf/server.crt
 
+# Require clients to present a trusted certificate (enable mTLS)
+tlsRequireTrustedClientCertOnConnect=true
+
 ### --- Authentication --- ###
 
 # Enable authentication
@@ -305,4 +308,3 @@ brokerServicePurgeInactiveFrequencyInSeconds=60
 
 # The maximum netty frame size in bytes. Any message received larger than this will be rejected. The default value is 5MB.
 nettyMaxFrameSizeBytes=5253120
-

--- a/tests/end_to_end.test.js
+++ b/tests/end_to_end.test.js
@@ -34,6 +34,10 @@ const Pulsar = require('../index');
         operationTimeoutSeconds: 30,
         connectionTimeoutMs: 20000,
         listenerName,
+        ...(serviceUrl.startsWith('pulsar+ssl://') || serviceUrl.startsWith('https://') ? {
+          tlsCertificateFilePath: `${__dirname}/certificate/server.crt`,
+          tlsPrivateKeyFilePath: `${__dirname}/certificate/server.key`,
+        } : {}),
       });
 
       const topic = 'persistent://public/default/produce-consume';


### PR DESCRIPTION
### Motivation
Support separate TLS handshake certificate and private key parameters independent from auth, enabling proper mTLS handshake configuration on the client.

### Modifications
- Add tlsCertificateFilePath and tlsPrivateKeyFilePath to ClientConfig.
- Pass them to the C client via pulsar_client_configuration_set_tls_certificate_file_path and pulsar_client_configuration_set_tls_private_key_file_path.
- Update end_to_end test to provide client cert/key for TLS endpoints under mTLS.

### Verifying this change
- Added and ran targeted tests for Produce/Consume to pulsar+ssl:// and https:// endpoints; tests pass when providing client cert/key.

### Documentation
- [x] doc-not-needed (API is discoverable via type definitions and examples).