### PR TITLE
feat: add replicateSubscriptionState to ConsumerConfig

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -110,6 +110,7 @@ export interface ConsumerConfig {
   deadLetterPolicy?: DeadLetterPolicy;
   batchReceivePolicy?: ConsumerBatchReceivePolicy;
   keySharedPolicy?: KeySharedPolicy;
+  replicateSubscriptionState?: boolean;
 }
 
 export class Consumer {

--- a/src/ConsumerConfig.cc
+++ b/src/ConsumerConfig.cc
@@ -62,6 +62,7 @@ static const std::string CFG_KEY_SHARED_POLICY_MODE = "keyShareMode";
 static const std::string CFG_KEY_SHARED_POLICY_ALLOW_OUT_OF_ORDER = "allowOutOfOrderDelivery";
 static const std::string CFG_KEY_SHARED_POLICY_STICKY_RANGES = "stickyRanges";
 static const std::string CFG_CRYPTO_KEY_READER = "cryptoKeyReader";
+static const std::string CFG_REPLICATE_SUBSCRIPTION_STATE = "replicateSubscriptionState";
 
 static const std::map<std::string, pulsar_consumer_type> SUBSCRIPTION_TYPE = {
     {"Exclusive", pulsar_ConsumerExclusive},
@@ -399,6 +400,13 @@ void ConsumerConfig::InitConfig(std::shared_ptr<ThreadSafeDeferred> deferred,
       cppKeySharedPolicy.setStickyRanges(stickyRanges);
     }
     this->cConsumerConfig.get()->consumerConfiguration.setKeySharedPolicy(cppKeySharedPolicy);
+  }
+
+  if (consumerConfig.Has(CFG_REPLICATE_SUBSCRIPTION_STATE) &&
+      consumerConfig.Get(CFG_REPLICATE_SUBSCRIPTION_STATE).IsBoolean()) {
+    bool replicateSubscriptionState = consumerConfig.Get(CFG_REPLICATE_SUBSCRIPTION_STATE).ToBoolean();
+    this->cConsumerConfig.get()->consumerConfiguration.setReplicateSubscriptionStateEnabled(
+        replicateSubscriptionState);
   }
 }
 


### PR DESCRIPTION
## Motivation

Fixes #478

The `ConsumerConfig` interface was missing `replicateSubscriptionState`, which is needed for geo-replication failover scenarios where subscription cursor state should be synchronized across clusters.

## Changes

- Added `CFG_REPLICATE_SUBSCRIPTION_STATE` constant in `src/ConsumerConfig.cc`
- Added handling to pass the config value through to `ConsumerConfiguration::setReplicateSubscriptionStateEnabled()` on the underlying C++ object
- Added `replicateSubscriptionState?: boolean` to the `ConsumerConfig` TypeScript interface in `index.d.ts`
- Added a test case in `tests/consumer.test.js` to verify the option can be set when creating a consumer