### PR TITLE
[feat] Expose message replication metadata

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -192,6 +192,8 @@ export class Message {
   getPartitionKey(): string;
   getOrderingKey(): string;
   getProducerName(): string;
+  isReplicated(): boolean;
+  getReplicatedFrom(): string;
   getEncryptionContext(): EncryptionContext | null;
 }
 

--- a/src/Message.cc
+++ b/src/Message.cc
@@ -63,6 +63,8 @@ Napi::Object Message::Init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("getPartitionKey", &Message::GetPartitionKey),
        InstanceMethod("getOrderingKey", &Message::GetOrderingKey),
        InstanceMethod("getProducerName", &Message::GetProducerName),
+       InstanceMethod("isReplicated", &Message::GetIsReplicated),
+       InstanceMethod("getReplicatedFrom", &Message::GetReplicatedFrom),
        InstanceMethod("getEncryptionContext", &Message::GetEncryptionContext)});
 
   constructor = Napi::Persistent(func);
@@ -170,6 +172,29 @@ Napi::Value Message::GetProducerName(const Napi::CallbackInfo &info) {
     return env.Null();
   }
   return Napi::String::New(env, pulsar_message_get_producer_name(this->cMessage.get()));
+}
+
+Napi::Value Message::GetIsReplicated(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (!ValidateCMessage(env)) {
+    return env.Null();
+  }
+
+  const char *replicatedFrom = pulsar_message_get_replicated_from(this->cMessage.get());
+  return Napi::Boolean::New(env, replicatedFrom && replicatedFrom[0] != '\0');
+}
+
+Napi::Value Message::GetReplicatedFrom(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (!ValidateCMessage(env)) {
+    return env.Null();
+  }
+
+  const char *replicatedFrom = pulsar_message_get_replicated_from(this->cMessage.get());
+  if (!replicatedFrom) {
+    return Napi::String::New(env, "");
+  }
+  return Napi::String::New(env, replicatedFrom);
 }
 
 Napi::Value Message::GetEncryptionContext(const Napi::CallbackInfo &info) {

--- a/src/Message.cc
+++ b/src/Message.cc
@@ -63,7 +63,7 @@ Napi::Object Message::Init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("getPartitionKey", &Message::GetPartitionKey),
        InstanceMethod("getOrderingKey", &Message::GetOrderingKey),
        InstanceMethod("getProducerName", &Message::GetProducerName),
-       InstanceMethod("isReplicated", &Message::GetIsReplicated),
+       InstanceMethod("isReplicated", &Message::IsReplicated),
        InstanceMethod("getReplicatedFrom", &Message::GetReplicatedFrom),
        InstanceMethod("getEncryptionContext", &Message::GetEncryptionContext)});
 
@@ -174,7 +174,7 @@ Napi::Value Message::GetProducerName(const Napi::CallbackInfo &info) {
   return Napi::String::New(env, pulsar_message_get_producer_name(this->cMessage.get()));
 }
 
-Napi::Value Message::GetIsReplicated(const Napi::CallbackInfo &info) {
+Napi::Value Message::IsReplicated(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   if (!ValidateCMessage(env)) {
     return env.Null();

--- a/src/Message.h
+++ b/src/Message.h
@@ -46,7 +46,7 @@ class Message : public Napi::ObjectWrap<Message> {
   Napi::Value GetPartitionKey(const Napi::CallbackInfo &info);
   Napi::Value GetOrderingKey(const Napi::CallbackInfo &info);
   Napi::Value GetProducerName(const Napi::CallbackInfo &info);
-  Napi::Value GetIsReplicated(const Napi::CallbackInfo &info);
+  Napi::Value IsReplicated(const Napi::CallbackInfo &info);
   Napi::Value GetReplicatedFrom(const Napi::CallbackInfo &info);
   Napi::Value GetRedeliveryCount(const Napi::CallbackInfo &info);
   Napi::Value GetEncryptionContext(const Napi::CallbackInfo &info);

--- a/src/Message.h
+++ b/src/Message.h
@@ -46,6 +46,8 @@ class Message : public Napi::ObjectWrap<Message> {
   Napi::Value GetPartitionKey(const Napi::CallbackInfo &info);
   Napi::Value GetOrderingKey(const Napi::CallbackInfo &info);
   Napi::Value GetProducerName(const Napi::CallbackInfo &info);
+  Napi::Value GetIsReplicated(const Napi::CallbackInfo &info);
+  Napi::Value GetReplicatedFrom(const Napi::CallbackInfo &info);
   Napi::Value GetRedeliveryCount(const Napi::CallbackInfo &info);
   Napi::Value GetEncryptionContext(const Napi::CallbackInfo &info);
   bool ValidateCMessage(Napi::Env env);

--- a/tests/end_to_end.test.js
+++ b/tests/end_to_end.test.js
@@ -73,6 +73,8 @@ const Pulsar = require('../index');
         const msg = await consumer.receive();
         consumer.acknowledge(msg);
         expect(msg.getProducerName()).toBe(producerName);
+        expect(msg.isReplicated()).toBe(false);
+        expect(msg.getReplicatedFrom()).toBe('');
         results.push(msg.getData().toString());
       }
       expect(lodash.difference(messages, results)).toEqual([]);

--- a/tstest.ts
+++ b/tstest.ts
@@ -297,6 +297,8 @@ import Pulsar = require('./index');
   const publishTime: number = message1.getPublishTimestamp();
   const eventTime: number = message1.getEventTimestamp();
   const redeliveryCount: number = message1.getRedeliveryCount();
+  const isReplicated: boolean = message1.isReplicated();
+  const replicatedFrom: string = message1.getReplicatedFrom();
   const partitionKey: string = message1.getPartitionKey();
 
   const message3: Pulsar.Message = await reader1.readNext();


### PR DESCRIPTION
### What changed

- Expose `Message.isReplicated()` and `Message.getReplicatedFrom()` from the Node.js binding.
- Add TypeScript definitions for both methods.
- Assert the default non-replicated message behavior in the end-to-end test and type-check sample.

### Why

Consumers need access to Pulsar replication-origin metadata to distinguish locally produced messages from messages geo-replicated from another cluster. This implements apache/pulsar-client-node#480 on top of the C++ client API added in apache/pulsar-client-cpp#583.

`isReplicated()` is derived from whether `getReplicatedFrom()` returns a non-empty cluster name.

Fixes #480

### Validation

- `npm run type-check`
- `npx clang-format-lint src/Message.cc src/Message.h`
- `npx node-pre-gyp configure build`
- `node -e "const Pulsar=require('./'); console.log(typeof Pulsar.Message.prototype.isReplicated, typeof Pulsar.Message.prototype.getReplicatedFrom)"`
- `npx eslint tests/end_to_end.test.js` (passes with existing warnings)